### PR TITLE
Add the missing excon gem

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -36,6 +36,7 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   end
 
   def translate_exception(err)
+    require 'excon'
     case err
     when Excon::Errors::Unauthorized
       MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."

--- a/manageiq-providers-nuage.gemspec
+++ b/manageiq-providers-nuage.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
+  s.add_runtime_dependency "excon", "~>0.40"
+
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Without this gem I was getting error about the missing Excon constant while trying to log into Nuage provider. This patch adds the same version as the one currently used in OpenStack provider.