### PR TITLE
Fix a problem when no policy groups exist

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
@@ -70,7 +70,7 @@ module ManageIQ::Providers
 
     def get_policy_groups
       policy_group = @vsd_client.get_policy_groups
-      process_collection(policy_group, :security_groups) { |pg| parse_policy_group(pg) }
+      process_collection(policy_group, :security_groups) { |pg| parse_policy_group(pg) } if policy_group
     end
 
     def to_cidr(netmask)


### PR DESCRIPTION
In case no policy groups are retrieved from the Nuage provider, `nil` is returned causing a problem processing the collection. This patch makes a simple check to skip processing should the list be nil.

@pdellaert Is empty list of policy groups an indication of some other error that should not be handled just by skipping them in the Nuage parser?

@miq-bot assign @juliancheal 
@miq-bot add_label bug