### PR TITLE
Introduce Nuage event catcher

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkManager
   include SupportsFeatureMixin
-
+  require_nested :EventCatcher
+  require_nested :EventParser
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
@@ -20,5 +21,23 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
 
   def self.description
     @description ||= "Nuage Network Manager".freeze
+  end
+
+  def authentications_to_validate
+    at = [:default]
+    at << :amqp if has_authentication_type?(:amqp)
+    at
+  end
+
+  def supported_auth_types
+    %w(default amqp)
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  def self.event_monitor_class
+    ManageIQ::Providers::Nuage::NetworkManager::EventCatcher
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Nuage::NetworkManager
+  end
+
+  def self.settings_name
+    :event_catcher_nuage_network
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
@@ -1,0 +1,41 @@
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler < Qpid::Proton::Handler::MessagingHandler
+  def initialize(options = {})
+    require 'qpid_proton'
+
+    super()
+    @options = options
+
+    @url = @options.delete(:url)
+    @topics = @options.delete(:topics)
+    @test_connection = @options.delete(:test_connection)
+    @message_handler_block = @options.delete(:message_handler_block)
+  end
+
+  def on_start(event)
+    @conn = event.container.connect(@url, @options)
+    unless @test_connection
+      @topics.each { |topic| event.container.create_receiver(@conn, :source => "topic://#{topic}") }
+    end
+  end
+
+  def on_connection_opened(event)
+    # In case connection test was requested, close the connection immediately.
+    event.container.stop if @test_connection
+  end
+
+  def on_connection_error(_event)
+    raise MiqException::MiqInvalidCredentialsError, "Connection failed due to bad username or password"
+  end
+
+  def on_transport_error(_event)
+    raise MiqException::MiqHostError, "Transport error"
+  end
+
+  def on_message(event)
+    @message_handler_block.call(JSON.parse(event.message.body)) if @message_handler_block
+  end
+
+  def stop
+    @conn.close
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -1,0 +1,35 @@
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def event_monitor_handle
+    unless @event_monitor_handle
+      options = @ems.event_monitor_options
+      options[:topics] = worker_settings[:topics]
+      @event_monitor_handle = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream.new(options)
+    end
+    @event_monitor_handle
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  # Start monitoring for events. This method blocks forever until stop_event_monitor is called.
+  def monitor_events
+    event_monitor_handle.start do |event|
+      event_monitor_running
+      @queue.enq(event)
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.try!(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def queue_event(event)
+    event_hash = ManageIQ::Providers::Nuage::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -1,0 +1,45 @@
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
+  include Vmdb::Logging
+
+  def self.test_amqp_connection(options = {})
+    # Ensure we just test the connection. AMQP channel will be established and
+    # started, however it will be immediately stopped.
+    options[:test_connection] = true
+    begin
+      stream = new(options)
+      stream.connection.run
+      true
+    rescue => e
+      _log.info("#{log_prefix} Failed connecting to ActiveMQ: #{e.message}")
+      raise
+    end
+  end
+
+  def self.log_prefix
+    "MIQ(#{self.class.name})"
+  end
+
+  def initialize(options = {})
+    require 'qpid_proton'
+
+    @options = options
+  end
+
+  def start(&message_handler_block)
+    _log.debug("#{self.class.log_prefix} Opening amqp connection using options #{@options}")
+    @options[:message_handler_block] = message_handler_block if message_handler_block
+    connection.run
+  end
+
+  def stop
+    @handler.stop
+  end
+
+  def connection
+    unless @connection
+      @handler = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(@options)
+      @connection = Qpid::Proton::Reactor::Container.new(@handler)
+    end
+    @connection
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Nuage::NetworkManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    event_type = "#{event['entityType']}_#{event['type'].downcase}"
+    {
+      :source     => "NUAGE",
+      :event_type => event_type,
+      :timestamp  => DateTime.strptime((event["eventReceivedTime"] / 1000).to_s, '%s').to_s,
+      :message    => event_type,
+      :vm_ems_ref => nil,
+      :full_data  => event.to_hash,
+      :ems_id     => ems_id
+    }
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,9 @@
   :nuage_network:
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
+:workers:
+  :worker_base:
+    :event_catcher:
+      :event_catcher_nuage_network:
+        :topics:
+          - topic/CNAMessages

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -21,4 +21,12 @@ FactoryGirl.define do
       ems.authentications << FactoryGirl.create(:authentication, cred)
     end
   end
+
+  factory :ems_nuage_network_with_authentication,
+          :parent => :ems_nuage_network do
+    after :create do |x|
+      x.authentications << FactoryGirl.create(:authentication)
+      x.authentications << FactoryGirl.create(:authentication, :authtype => "amqp")
+    end
+  end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -6,4 +6,20 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
   it '.description' do
     expect(described_class.description).to eq('Nuage Network Manager')
   end
+
+  context 'validation' do
+    before :each do
+      @ems = FactoryGirl.create(:ems_nuage_network_with_authentication)
+    end
+
+    it 'raises error for unsupported auth type' do
+      creds = {}
+      creds[:unsupported] = {:userid => "unsupported", :password => "password"}
+      @ems.endpoints << Endpoint.create(:role => 'unsupported', :hostname => 'hostname', :port => 1111)
+      @ems.update_authentication(creds, :save => false)
+      expect do
+        @ems.verify_credentials(:unsupported)
+      end.to raise_error(MiqException::MiqInvalidCredentialsError)
+    end
+  end
 end


### PR DESCRIPTION
This commit introduces the full blown event catcher for Nuage manager based on ActiveMQ message bus. Further to default authentication, AMQP is now provided via Qpid Proton gem, along with the corresponding message handler responsible for the delivery of messages into CFME.