### PR TITLE
Install qpid_proton for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - '2.3.3'
 - '2.4.1'
-sudo: false
+sudo: required
 cache: bundler
 env:
   global:
@@ -11,6 +11,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
+before_install: sudo bin/qpid_install.sh
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:

--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Ensure correct Ruby environment is used.
+. ~/.rvm/scripts/rvm
+rvm use $TRAVIS_RUBY_VERSION
+
+# We have to extract the major and minor ruby versions so that we can set proper GEM_HOME
+ruby_version=`echo $TRAVIS_RUBY_VERSION | egrep -o '[[:digit:]]\.[[:digit:]]'`
+
+# As we are installing the Gem built from source, we have to set the proper
+# GEM_HOME. This will ensure that the gem will be installed in a place where it
+# will be picked by bundler.
+export GEM_HOME=/home/travis/build/ManageIQ/manageiq-providers-nuage/vendor/bundle/ruby/$ruby_version.0
+
+# Install the dev dependencies for building Qpid proton system library.
+sudo apt-get install -y gcc cmake cmake-curses-gui uuid-dev
+sudo apt-get install -y libssl-dev
+sudo apt-get install -y libsasl2-2 libsasl2-dev
+sudo apt-get install -y swig
+
+# Get the latest Qpid Proton source
+cd $HOME/build
+git clone https://github.com/apache/qpid-proton.git
+cd qpid-proton
+
+# There is a strange dependency on JSON that we need to change to version of
+# at least 2; otherwise there will be a conflict.
+sed -i .bak -e 's/ 0/ 2/' proton-c/bindings/ruby/qpid_proton.gemspec.in
+
+# Configure the source of Qpid Proton.
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_BINDINGS=OFF
+
+# Make system libraries and the gem.
+make all
+
+# Install system libraries
+sudo make install
+
+# Manually install the Ruby Gem. This will be installed inside $GEM_HOME directory.
+gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem

--- a/manageiq-providers-nuage.gemspec
+++ b/manageiq-providers-nuage.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "excon", "~>0.40"
+  s.add_runtime_dependency "excon",       "~>0.40"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -1,0 +1,9 @@
+describe ManageIQ::Providers::Nuage::NetworkManager do
+  it '.ems_type' do
+    expect(described_class.ems_type).to eq('nuage_network')
+  end
+
+  it '.description' do
+    expect(described_class.description).to eq('Nuage Network Manager')
+  end
+end


### PR DESCRIPTION
The worker used by Travis does not have the most current version of the Qpid Proton installed, so we need to manually install it from source. This patch also adds a simple spec that chects that Qpid gem is properly installed.
