### PR TITLE
Implement graph inventory refresh for network manager

### DIFF
--- a/app/models/manageiq/providers/nuage/builder.rb
+++ b/app/models/manageiq/providers/nuage/builder.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Nuage::Builder
+  class << self
+    def build_inventory(ems, target)
+      inventory(
+        ems,
+        target,
+        ManageIQ::Providers::Nuage::Inventory::Collector::NetworkManager,
+        ManageIQ::Providers::Nuage::Inventory::Persister::NetworkManager,
+        [ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager]
+      )
+    end
+
+    private
+
+    def inventory(manager, raw_target, collector_class, persister_class, parsers_classes)
+      collector = collector_class.new(manager, raw_target)
+      persister = persister_class.new(manager, raw_target)
+
+      ::ManageIQ::Providers::Nuage::Inventory.new(
+        persister,
+        collector,
+        parsers_classes.map(&:new)
+      )
+    end
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory.rb
+++ b/app/models/manageiq/providers/nuage/inventory.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Nuage::Inventory < ManagerRefresh::Inventory
+  require_nested :Collector
+  require_nested :Parser
+  require_nested :Persister
+end

--- a/app/models/manageiq/providers/nuage/inventory/collector.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector.rb
@@ -1,0 +1,21 @@
+class ManageIQ::Providers::Nuage::Inventory::Collector < ManagerRefresh::Inventory::Collector
+  require_nested :NetworkManager
+
+  def initialize(_manager, _target)
+    super
+
+    initialize_inventory_sources
+  end
+
+  def initialize_inventory_sources
+    @cloud_subnets   = []
+    @security_groups = []
+    @network_groups  = []
+    @zones           = {}
+    @domains         = {}
+  end
+
+  def vsd_client
+    @vsd_client ||= manager.connect
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Nuage::Inventory::Collector::NetworkManager < ManageIQ::Providers::Nuage::Inventory::Collector
+  def cloud_subnets
+    return @cloud_subnets if @cloud_subnets.any?
+    @cloud_subnets = vsd_client.get_subnets
+  end
+
+  def security_groups
+    return @security_groups if @security_groups.any?
+    @security_groups = vsd_client.get_policy_groups
+  end
+
+  def network_groups
+    return @network_groups if @network_groups.any?
+    @network_groups = vsd_client.get_enterprises
+  end
+
+  def zones
+    return @zones if @zones.any?
+    @zones = vsd_client.get_zones.map { |zone| [zone['ID'], zone] } .to_h
+  end
+
+  def domains
+    return @domains if @domains.any?
+    @domains = vsd_client.get_domains.map { |domain| [domain['ID'], domain] } .to_h
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory/parser.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Nuage::Inventory::Parser < ManagerRefresh::Inventory::Parser
+  require_nested :NetworkManager
+end

--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -1,0 +1,66 @@
+class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::Providers::Nuage::Inventory::Parser
+  def parse
+    cloud_subnets
+    security_groups
+    network_groups
+  end
+
+  private
+
+  def cloud_subnets
+    collector.cloud_subnets.each do |subnet|
+      extra = map_extra_attributes(subnet['parentID'])
+      persister.cloud_subnets.find_or_build(subnet['ID']).assign_attributes(
+        :name             => subnet['name'],
+        :cidr             => to_cidr(subnet['address'], subnet['netmask']),
+        :network_protocol => subnet['IPType'].downcase,
+        :gateway          => subnet['gateway'],
+        :dhcp_enabled     => false,
+        :extra_attributes => extra,
+        :network_group    => persister.network_groups.lazy_find(extra["enterprise_id"])
+      )
+    end
+  end
+
+  def security_groups
+    collector.security_groups.each do |sg|
+      domain_id = sg['parentID']
+      domain = collector.domains[domain_id]
+
+      persister.security_groups.find_or_build(sg['ID']).assign_attributes(
+        :name          => sg['name'],
+        :network_group => persister.network_groups.lazy_find(domain['parentID'])
+      )
+    end
+  end
+
+  def network_groups
+    collector.network_groups.each do |ng|
+      persister.network_groups.find_or_build(ng['ID']).assign_attributes(
+        :name   => ng['name'],
+        :status => 'active'
+      )
+    end
+  end
+
+  def map_extra_attributes(zone_id)
+    zone = collector.zones[zone_id]
+    domain_id = zone['parentID']
+    domain = collector.domains[domain_id]
+    network_group_id = domain['parentID']
+    network_group = collector.network_groups.find { |ng| ng['ID'] == network_group_id }
+
+    {
+      "enterprise_name" => network_group['name'],
+      "enterprise_id"   => domain['parentID'],
+      "domain_name"     => domain['name'],
+      "domain_id"       => domain_id,
+      "zone_name"       => zone['name'],
+      "zone_id"         => zone_id
+    }
+  end
+
+  def to_cidr(address, netmask)
+    address + '/' + netmask.to_s.split(".").map { |e| e.to_i.to_s(2).rjust(8, "0") }.join.count("1").to_s
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory/persister.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Nuage::Inventory::Persister < ManagerRefresh::Inventory::Persister
+  require_nested :NetworkManager
+
+  protected
+
+  def network
+    ManageIQ::Providers::Nuage::InventoryCollectionDefault::NetworkManager
+  end
+
+  def targeted
+    false
+  end
+
+  def strategy
+    nil
+  end
+
+  def shared_options
+    settings_options = options[:inventory_collections].try(:to_hash) || {}
+
+    settings_options.merge(
+      :strategy => strategy,
+      :targeted => targeted,
+    )
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister/network_manager.rb
@@ -1,0 +1,8 @@
+class ManageIQ::Providers::Nuage::Inventory::Persister::NetworkManager < ManageIQ::Providers::Nuage::Inventory::Persister
+  def initialize_inventory_collections
+    add_inventory_collections(
+      network,
+      %i(cloud_subnets security_groups network_groups)
+    )
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory_collection_default/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory_collection_default/network_manager.rb
@@ -1,0 +1,69 @@
+class ManageIQ::Providers::Nuage::InventoryCollectionDefault::NetworkManager < ManagerRefresh::InventoryCollectionDefault::NetworkManager
+  class << self
+    def cloud_subnets(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet,
+        :inventory_object_attributes => [
+          :type,
+          :ems_id,
+          :ems_ref,
+          :name,
+          :cidr,
+          :network_protocol,
+          :gateway,
+          :dhcp_enabled,
+          :extra_attributes,
+          :network_group
+        ]
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def security_groups(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup,
+        :inventory_object_attributes => [
+          :type,
+          :ems_id,
+          :ems_ref,
+          :name,
+          :network_group
+        ]
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def network_groups(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Nuage::NetworkManager::NetworkGroup,
+        :inventory_object_attributes => [
+          :type,
+          :ems_id,
+          :ems_ref,
+          :name,
+          :status
+        ]
+      }
+
+      # super(attributes.merge!(extra_attributes))
+      super_network_groups(attributes.merge!(extra_attributes))
+    end
+
+    # TODO(miha-plesko) Remove this function once it gets merged into core repo i.e. once this PR gets merged:
+    # https://github.com/ManageIQ/manageiq/pull/16136
+    # Doing this, also make sure that `network_groups` function then calls `super` instead `super_network_groups`
+    def super_network_groups(extra_attributes = {})
+      attributes = {
+        :model_class    => ::NetworkGroup,
+        :association    => :network_groups,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.try(:network_manager).try(:id) || persister.manager.id },
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -1,9 +1,14 @@
 class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkManager
   include SupportsFeatureMixin
+
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
   require_nested :VsdClient
+  require_nested :CloudSubnet
+  require_nested :SecurityGroup
+  require_nested :NetworkGroup
+
   supports :ems_network_new
 
   include Vmdb::Logging

--- a/app/models/manageiq/providers/nuage/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresher.rb
@@ -9,5 +9,38 @@ module ManageIQ::Providers
     def post_process_refresh_classes
       []
     end
+
+    def collect_inventory_for_targets(ems, targets)
+      log_header = format_ems_for_logging(ems)
+      targets_with_data = targets.collect do |target|
+        target_name = target.try(:name) || target.try(:event_type)
+
+        _log.info("#{log_header} Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]...")
+
+        if refresher_options.try(:[], :inventory_object_refresh)
+          inventory = ManageIQ::Providers::Nuage::Builder.build_inventory(ems, target)
+        end
+
+        _log.info("#{log_header} Filtering inventory...Complete")
+        [target, inventory]
+      end
+
+      targets_with_data
+    end
+
+    def parse_targeted_inventory(ems, _target, inventory)
+      log_header = format_ems_for_logging(ems)
+      _log.debug("#{log_header} Parsing inventory...")
+      hashes, = Benchmark.realtime_block(:parse_inventory) do
+        if refresher_options.try(:[], :inventory_object_refresh)
+          inventory.inventory_collections
+        else
+          ManageIQ::Providers::Nuage::NetworkManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+        end
+      end
+      _log.debug("#{log_header} Parsing inventory...Complete")
+
+      hashes
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,4 +12,4 @@
     :user:
 :ems_refresh:
   :nuage_network:
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -2,6 +2,27 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   ALL_REFRESH_SETTINGS = [
     {
       :inventory_object_refresh => false
+    },
+    {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :default,
+      },
+    }, {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => true,
+      },
+    }, {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => false,
+      },
+    }, {
+      :inventory_object_saving_strategy => :recursive,
+      :inventory_object_refresh         => true
     }
   ].freeze
 


### PR DESCRIPTION
With this commit we implement whatever is needed for the fancy new graph inventory refresh to step in. For now we keep legacy refresher also in place (switchable in settings.yml), but the plan is to migrate to the new refresher completely.

Exactly same unit tests that were passing for legacy refresher are now passing for both the legacy refresher and the new graph refresher.

Depends on: https://github.com/ManageIQ/manageiq-providers-nuage/pull/12
Depends on: https://github.com/ManageIQ/manageiq/pull/16136

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement

/cc @gberginc 