### PR TITLE
Let Refresher extend the new ManagerRefresher

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresher.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers
-  class Nuage::NetworkManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+  class Nuage::NetworkManager::Refresher < ManageIQ::Providers::BaseManager::ManagerRefresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
     def parse_legacy_inventory(ems)
@@ -8,39 +8,6 @@ module ManageIQ::Providers
 
     def post_process_refresh_classes
       []
-    end
-
-    def collect_inventory_for_targets(ems, targets)
-      log_header = format_ems_for_logging(ems)
-      targets_with_data = targets.collect do |target|
-        target_name = target.try(:name) || target.try(:event_type)
-
-        _log.info("#{log_header} Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]...")
-
-        if refresher_options.try(:[], :inventory_object_refresh)
-          inventory = ManageIQ::Providers::Nuage::Builder.build_inventory(ems, target)
-        end
-
-        _log.info("#{log_header} Filtering inventory...Complete")
-        [target, inventory]
-      end
-
-      targets_with_data
-    end
-
-    def parse_targeted_inventory(ems, _target, inventory)
-      log_header = format_ems_for_logging(ems)
-      _log.debug("#{log_header} Parsing inventory...")
-      hashes, = Benchmark.realtime_block(:parse_inventory) do
-        if refresher_options.try(:[], :inventory_object_refresh)
-          inventory.inventory_collections
-        else
-          ManageIQ::Providers::Nuage::NetworkManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
-        end
-      end
-      _log.debug("#{log_header} Parsing inventory...Complete")
-
-      hashes
     end
   end
 end


### PR DESCRIPTION
Recently the ManagerRefresher was introduced in the core repository. By extending it, we cleanup our Nuage::NetworkManager::Refresher so that it no longer implements the two copy-pasted functions:

- collect_inventory_for_targets
- parse_targeted_inventory

@miq-bot assign @Ladas 
@miq-bot add_label refactoring
