### PR TITLE
[WIP] Build with qpid_proton gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - '2.3.3'
 - '2.4.1'
-sudo: required
+sudo: false
 cache: bundler
 env:
   global:
@@ -11,7 +11,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
-before_install: sudo bin/qpid_install.sh
+before_install: bin/qpid_install.sh
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:

--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -13,10 +13,10 @@ ruby_version=`echo $TRAVIS_RUBY_VERSION | egrep -o '[[:digit:]]\.[[:digit:]]'`
 export GEM_HOME=/home/travis/build/ManageIQ/manageiq-providers-nuage/vendor/bundle/ruby/$ruby_version.0
 
 # Install the dev dependencies for building Qpid proton system library.
-sudo apt-get install -y gcc cmake cmake-curses-gui uuid-dev
-sudo apt-get install -y libssl-dev
-sudo apt-get install -y libsasl2-2 libsasl2-dev
-sudo apt-get install -y swig
+apt-get install -y gcc cmake cmake-curses-gui uuid-dev
+apt-get install -y libssl-dev
+apt-get install -y libsasl2-2 libsasl2-dev
+apt-get install -y swig
 
 # Get the latest Qpid Proton source
 cd $HOME/build
@@ -30,13 +30,13 @@ sed -i .bak -e 's/ 0/ 2/' proton-c/bindings/ruby/qpid_proton.gemspec.in
 # Configure the source of Qpid Proton.
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_BINDINGS=OFF
+cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/pkg -DSYSINSTALL_BINDINGS=OFF
 
 # Make system libraries and the gem.
 make all
 
 # Install system libraries
-sudo make install
+make install
 
 # Manually install the Ruby Gem. This will be installed inside $GEM_HOME directory.
-gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem
+gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem -- --with-qpid-proton-lib=$HOME/pkg/lib --with-qpid-proton-include=$HOME/pkg/include/


### PR DESCRIPTION
With the addition of qpid_proton gem into the core Gemfile, this patch
allows for installation of this gem automatically from the provided
GitHub repository.