### PR TITLE
Fix Qpid proton Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
-before_install: sudo bin/qpid_install.sh
+before_install: bin/qpid_install.sh
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:

--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -30,13 +30,13 @@ sed -i .bak -e 's/ 0/ 2/' proton-c/bindings/ruby/qpid_proton.gemspec.in
 # Configure the source of Qpid Proton.
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_BINDINGS=OFF
+cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/pkg -DSYSINSTALL_BINDINGS=OFF
 
 # Make system libraries and the gem.
 make all
 
 # Install system libraries
-sudo make install
+make install
 
 # Manually install the Ruby Gem. This will be installed inside $GEM_HOME directory.
-gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem
+gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem -- --with-qpid-proton-lib=$HOME/pkg/lib --with-qpid-proton-include=$HOME/pkg/include/


### PR DESCRIPTION
Because qpid-proton needs to be built from source, additional system
packages are needed (installed with sudo rights). This caused that the
vendor bundle is created by the root user and resulted in Bundler not
being able to install other gems.

This patch now removes the use of sudo to the bare minimum, namely
installing the packages required to build qpid-proton from source.