### PR TITLE
Implement targeted refresh for NetworkManager

### DIFF
--- a/app/models/manageiq/providers/nuage/builder.rb
+++ b/app/models/manageiq/providers/nuage/builder.rb
@@ -1,6 +1,26 @@
 class ManageIQ::Providers::Nuage::Builder
   class << self
     def build_inventory(ems, target)
+      case target
+      when ManageIQ::Providers::Nuage::NetworkManager
+        network_manager_inventory(ems, target)
+      when ManagerRefresh::TargetCollection
+        inventory(
+          ems,
+          target,
+          ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection,
+          ManageIQ::Providers::Nuage::Inventory::Persister::TargetCollection,
+          [ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager]
+        )
+      else
+        # Fallback to ems refresh
+        network_manager_inventory(ems, target)
+      end
+    end
+
+    private
+
+    def network_manager_inventory(ems, target)
       inventory(
         ems,
         target,
@@ -9,8 +29,6 @@ class ManageIQ::Providers::Nuage::Builder
         [ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager]
       )
     end
-
-    private
 
     def inventory(manager, raw_target, collector_class, persister_class, parsers_classes)
       collector = collector_class.new(manager, raw_target)

--- a/app/models/manageiq/providers/nuage/inventory/collector.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Nuage::Inventory::Collector < ManagerRefresh::Inventory::Collector
   require_nested :NetworkManager
+  require_nested :TargetCollection
 
   def initialize(_manager, _target)
     super

--- a/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
@@ -23,4 +23,20 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::NetworkManager < ManageI
     return @domains if @domains.any?
     @domains = vsd_client.get_domains.map { |domain| [domain['ID'], domain] } .to_h
   end
+
+  def security_group(ems_ref)
+    security_groups.find { |sg| sg['ID'] == ems_ref }
+  end
+
+  def network_group(ems_ref)
+    network_groups.find { |ng| ng['ID'] == ems_ref }
+  end
+
+  def zone(ems_ref)
+    zones[ems_ref]
+  end
+
+  def domain(ems_ref)
+    domains[ems_ref]
+  end
 end

--- a/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
@@ -1,0 +1,194 @@
+class ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection < ManageIQ::Providers::Nuage::Inventory::Collector
+  def initialize(_manager, _target)
+    super
+    initialize_cache
+    parse_targets!
+    infer_related_ems_refs!
+
+    # Reset the target cache, so we can access new targets inside
+    target.manager_refs_by_association_reset
+  end
+
+  def cloud_subnets
+    return [] if references(:cloud_subnets).blank?
+    references(:cloud_subnets).collect { |ems_ref| cloud_subnet(ems_ref) }
+    @cloud_subnets_map.values.compact
+  end
+
+  def security_groups
+    return [] if references(:security_groups).blank?
+    references(:security_groups).collect { |ems_ref| security_group(ems_ref) }
+    @security_groups_map.values.compact
+  end
+
+  def network_groups
+    return [] if references(:network_groups).blank?
+    references(:network_groups).collect { |ems_ref| network_group(ems_ref) }
+    @network_groups_map.values.compact
+  end
+
+  def cloud_subnet(ems_ref)
+    return @cloud_subnets_map[ems_ref] if @cloud_subnets_map.key?(ems_ref)
+    @cloud_subnets_map[ems_ref] = safe_call { vsd_client.get_subnet(ems_ref) }
+  end
+
+  def security_group(ems_ref)
+    return @security_groups_map[ems_ref] if @security_groups_map.key?(ems_ref)
+    @security_groups_map[ems_ref] = safe_call { vsd_client.get_policy_group(ems_ref) }
+  end
+
+  def network_group(ems_ref)
+    return @network_groups_map[ems_ref] if @network_groups_map.key?(ems_ref)
+    @network_groups_map[ems_ref] = safe_call { vsd_client.get_enterprise(ems_ref) }
+  end
+
+  def zone(ems_ref)
+    return @zones_map[ems_ref] if @zones_map.key?(ems_ref)
+    @zones_map[ems_ref] = safe_call { vsd_client.get_zone(ems_ref) }
+  end
+
+  def domain(ems_ref)
+    return @domains_map[ems_ref] if @domains_map.key?(ems_ref)
+    @domains_map[ems_ref] = safe_call { vsd_client.get_domain(ems_ref) }
+  end
+
+  private
+
+  def initialize_cache
+    @cloud_subnets_map         = {}
+    @security_groups_map       = {}
+    @network_groups_map        = {}
+    @zones_map                 = {}
+    @domains_map               = {}
+    @domains_per_network_group = {}
+  end
+
+  def domains_for_network_group(network_group_ems_ref)
+    ems_ref = network_group_ems_ref
+    @domains_per_network_group[ems_ref] ||= safe_list { vsd_client.get_domains_for_enterprise(ems_ref) }
+    @domains_per_network_group[ems_ref].each { |d| @domains_map[d['ID']] = d }
+    @domains_per_network_group[ems_ref]
+  end
+
+  def cloud_subnets_for_network_group(network_group_ems_ref)
+    domains_for_network_group(network_group_ems_ref).each_with_object([]) do |d, arr|
+      arr.push(safe_list { vsd_client.get_subnets_for_domain(d['ID']) })
+    end.flatten(1)
+  end
+
+  def security_groups_for_network_group(network_group_ems_ref)
+    domains_for_network_group(network_group_ems_ref).each_with_object([]) do |d, arr|
+      arr.push(safe_list { vsd_client.get_policy_groups_for_domain(d['ID']) })
+    end.flatten(1)
+  end
+
+  def network_group_ems_ref_for_cloud_subnet(cloud_subnet_ems_ref)
+    cloud_subnet = cloud_subnet(cloud_subnet_ems_ref)
+    return nil if cloud_subnet.nil?
+    domain_ems_ref = zone(cloud_subnet['parentID'])['parentID']
+    domain(domain_ems_ref)['parentID']
+  end
+
+  def network_group_ems_ref_for_security_group(security_group_ems_ref)
+    security_group = security_group(security_group_ems_ref)
+    return nil if security_group.nil?
+    domain(security_group['parentID'])['parentID']
+  end
+
+  def references(collection)
+    target.manager_refs_by_association.try(:[], collection).try(:[], :ems_ref).try(:to_a) || []
+  end
+
+  def parse_targets!
+    target.targets.each do |t|
+      case t
+      when CloudSubnet
+        add_simple_target!(:cloud_subnets, t.ems_ref)
+      when SecurityGroup
+        add_simple_target!(:security_groups, t.ems_ref)
+      when NetworkGroup
+        add_simple_target!(:network_groups, t.ems_ref)
+      end
+    end
+  end
+
+  def add_simple_target!(association, ems_ref)
+    return if ems_ref.blank?
+
+    target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref})
+  end
+
+  def infer_related_ems_refs!
+    infer_related_ems_refs_db!
+    infer_related_ems_refs_api!
+  end
+
+  def infer_related_ems_refs_db!
+    if references(:network_groups).any?
+      network_groups = manager.network_groups.where(:ems_ref => references(:network_groups))
+                              .includes(:cloud_subnets, :security_groups)
+      network_groups.each do |ng|
+        ng.cloud_subnets.collect(&:ems_ref).compact.each { |ems_ref| add_simple_target!(:cloud_subnets, ems_ref) }
+        ng.security_groups.collect(&:ems_ref).compact.each { |ems_ref| add_simple_target!(:security_groups, ems_ref) }
+      end
+    end
+
+    if references(:cloud_subnets).any?
+      cloud_subnets = manager.cloud_subnets.where(:ems_ref => references(:cloud_subnets))
+      cloud_subnets.each do |cloud_subnet|
+        next if cloud_subnet.network_group.nil?
+        add_simple_target!(:network_groups, cloud_subnet.network_group.ems_ref)
+        cloud_subnet.network_group.security_groups.each do |security_group|
+          add_simple_target!(:security_groups, security_group.ems_ref)
+        end
+      end
+    end
+
+    if references(:security_groups).any?
+      security_groups = manager.security_groups.where(:ems_ref => references(:security_groups))
+      security_groups.each do |security_group|
+        add_simple_target!(:network_groups, security_group.network_group.ems_ref) unless security_group.network_group.nil?
+      end
+    end
+  end
+
+  def infer_related_ems_refs_api!
+    references(:network_groups).each do |ng_ems_ref|
+      cloud_subnets_for_network_group(ng_ems_ref).each do |cloud_subnet|
+        add_simple_target!(:cloud_subnets, cloud_subnet['ID'])
+      end
+
+      security_groups_for_network_group(ng_ems_ref).each do |policy_group|
+        add_simple_target!(:security_groups, policy_group['ID'])
+      end
+    end
+
+    references(:cloud_subnets).each do |cs_ems_ref|
+      ng_ems_ref = network_group_ems_ref_for_cloud_subnet(cs_ems_ref)
+      next if ng_ems_ref.nil?
+      add_simple_target!(:network_groups, ng_ems_ref)
+      security_groups_for_network_group(ng_ems_ref).each do |policy_group|
+        add_simple_target!(:security_groups, policy_group['ID'])
+      end
+    end
+
+    references(:security_groups).each do |sg_ems_ref|
+      add_simple_target!(:network_groups, network_group_ems_ref_for_security_group(sg_ems_ref))
+    end
+  end
+
+  def safe_call
+    response = yield
+
+    # TODO: This error handling is funny because the vsd_client returns 'true' when any other status than 200 is
+    # returned :) We need to refactor the vsd_client and then rescue from actual errors here...
+    case response
+    when Array, Hash
+      response
+    end
+  end
+
+  def safe_list(&block)
+    safe_call(&block) || []
+  end
+end

--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   def security_groups
     collector.security_groups.each do |sg|
       domain_id = sg['parentID']
-      domain = collector.domains[domain_id]
+      domain = collector.domain(domain_id)
 
       persister.security_groups.find_or_build(sg['ID']).assign_attributes(
         :name          => sg['name'],
@@ -44,11 +44,11 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   end
 
   def map_extra_attributes(zone_id)
-    zone = collector.zones[zone_id]
+    zone = collector.zone(zone_id)
     domain_id = zone['parentID']
-    domain = collector.domains[domain_id]
+    domain = collector.domain(domain_id)
     network_group_id = domain['parentID']
-    network_group = collector.network_groups.find { |ng| ng['ID'] == network_group_id }
+    network_group = collector.network_group(network_group_id)
 
     {
       "enterprise_name" => network_group['name'],

--- a/app/models/manageiq/providers/nuage/inventory/persister.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Nuage::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :NetworkManager
+  require_nested :TargetCollection
 
   protected
 

--- a/app/models/manageiq/providers/nuage/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister/target_collection.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::Nuage::Inventory::Persister::TargetCollection < ManageIQ::Providers::Nuage::Inventory::Persister
+  def initialize_inventory_collections
+    add_inventory_collections_with_references(
+      network,
+      %i(cloud_subnets security_groups network_groups),
+      :parent => manager
+    )
+  end
+
+  private
+
+  def add_inventory_collections_with_references(inventory_collections_data, names, options = {})
+    names.each do |name|
+      add_inventory_collection_with_references(inventory_collections_data, name, references(name), options)
+    end
+  end
+
+  def add_inventory_collection_with_references(inventory_collections_data, name, manager_refs, options = {})
+    options = inventory_collections_data.send(
+      name,
+      :manager_uuids => manager_refs,
+      :strategy      => strategy,
+      :targeted      => true
+    ).merge(options)
+
+    add_inventory_collection(options)
+  end
+
+  def references(collection)
+    target.manager_refs_by_association.try(:[], collection).try(:[], :ems_ref).try(:to_a) || []
+  end
+
+  def targeted
+    true
+  end
+
+  def strategy
+    :local_db_find_missing_references
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -29,11 +29,47 @@ module ManageIQ::Providers
       _log.error('Error in connection for server ' + @server.to_s + ' ' + response.code.to_s)
     end
 
+    def get_enterprise(id)
+      response = @rest_call.get(@server + '/enterprises/' + id)
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Enterprise with ID not found: #{id}")
+          return
+        end
+        return JSON.parse(response.body).first
+      end
+      _log.error('Error in connection for server ' + @server.to_s + ' ' + response.code.to_s)
+    end
+
     def get_domains
       response = @rest_call.get(@server + '/domains')
       if response.code == 200
         if response.body == ''
           _log.warn('No domains present')
+          return
+        end
+        return JSON.parse(response.body)
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_domain(id)
+      response = @rest_call.get(@server + '/domains/' + id)
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Domain with ID not found: #{id}")
+          return
+        end
+        return JSON.parse(response.body).first
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_domains_for_enterprise(enterprise_id)
+      response = @rest_call.get(@server + '/enterprises/' + enterprise_id + '/domains')
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Domains for enterprise with ID not found: #{enterprise_id}")
           return
         end
         return JSON.parse(response.body)
@@ -55,6 +91,20 @@ module ManageIQ::Providers
       _log.error('Error in connection ' + response.code.to_s)
     end
 
+    def get_zone(id)
+      @rest_call.append_headers("X-Nuage-FilterType", "predicate")
+      @rest_call.append_headers("X-Nuage-Filter", "name ISNOT 'BackHaulZone'")
+      response = @rest_call.get(@server + '/zones/' + id)
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Zone with ID not found: #{id}")
+          return
+        end
+        return JSON.parse(response.body).first
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
     def get_subnets
       @rest_call.append_headers("X-Nuage-FilterType", "predicate")
       @rest_call.append_headers("X-Nuage-Filter", "name ISNOT 'BackHaulSubnet'")
@@ -66,6 +116,34 @@ module ManageIQ::Providers
         end
         subnets = JSON.parse(response.body)
         return subnets
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_subnet(id)
+      @rest_call.append_headers("X-Nuage-FilterType", "predicate")
+      @rest_call.append_headers("X-Nuage-Filter", "name ISNOT 'BackHaulSubnet'")
+      response = @rest_call.get(@server + '/subnets/' + id)
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Subnet with ID not found: #{id}")
+          return
+        end
+        return JSON.parse(response.body).first
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_subnets_for_domain(domain_id)
+      @rest_call.append_headers("X-Nuage-FilterType", "predicate")
+      @rest_call.append_headers("X-Nuage-Filter", "name ISNOT 'BackHaulSubnet'")
+      response = @rest_call.get(@server + '/domains/' + domain_id + '/subnets')
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Subnets for domain with ID not found: #{domain_id}")
+          return
+        end
+        return JSON.parse(response.body)
       end
       _log.error('Error in connection ' + response.code.to_s)
     end
@@ -99,6 +177,30 @@ module ManageIQ::Providers
       if response.code == 200
         if response.body == ''
           _log.warn('No policy Group present')
+          return
+        end
+        return JSON.parse(response.body)
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_policy_group(id)
+      response = @rest_call.get(@server + '/policygroups/' + id)
+      if response.code == 200
+        if response.body == ''
+          _log.warn("PolicyGroup with ID not found: #{id}")
+          return
+        end
+        return JSON.parse(response.body).first
+      end
+      _log.error('Error in connection ' + response.code.to_s)
+    end
+
+    def get_policy_groups_for_domain(domain_id)
+      response = @rest_call.get(@server + '/domains/' + domain_id + '/policygroups')
+      if response.code == 200
+        if response.body == ''
+          _log.warn("Domain with ID not found: #{domain_id}")
           return
         end
         return JSON.parse(response.body)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,4 @@
 :ems_refresh:
   :nuage_network:
     :inventory_object_refresh: true
+    :allow_targeted_refresh: true

--- a/spec/factories/cloud_subnet.rb
+++ b/spec/factories/cloud_subnet.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :cloud_subnet_nuage,
+          :class  => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet",
+          :parent => :cloud_subnet
+end

--- a/spec/factories/network_group.rb
+++ b/spec/factories/network_group.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :network_group_nuage, :class => "ManageIQ::Providers::Nuage::NetworkManager::NetworkGroup"
+end

--- a/spec/factories/security_group.rb
+++ b/spec/factories/security_group.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :security_group_nuage,
+          :class  => "ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup",
+          :parent => :security_group
+end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -1,0 +1,316 @@
+describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
+  TARGET_REFRESH_SETTINGS = [
+    {
+      :inventory_object_refresh => true,
+      :allow_targeted_refresh   => true,
+      :inventory_collections    => {
+        :saver_strategy => :default,
+      },
+    },
+    {
+      :inventory_object_refresh => true,
+      :allow_targeted_refresh   => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => true,
+      },
+    },
+    {
+      :inventory_object_refresh => true,
+      :allow_targeted_refresh   => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => false,
+      },
+    },
+    {
+      :inventory_object_saving_strategy => :recursive,
+      :inventory_object_refresh         => true,
+      :allow_targeted_refresh           => true,
+    }
+  ].freeze
+
+  before(:each) do
+    @ems = FactoryGirl.create(:ems_nuage_with_vcr_authentication, :port => 8443, :api_version => "v5_0", :security_protocol => "ssl-with-validation")
+  end
+
+  before(:each) do
+    userid   = Rails.application.secrets.nuage_network.try(:[], 'userid') || 'NUAGE_USER_ID'
+    password = Rails.application.secrets.nuage_network.try(:[], 'password') || 'NUAGE_PASSWORD'
+    hostname = @ems.hostname
+
+    # Ensure that VCR will obfuscate the basic auth
+    VCR.configure do |c|
+      # workaround for escaping host
+      c.before_playback do |interaction|
+        interaction.filter!(CGI.escape(hostname), hostname)
+        interaction.filter!(CGI.escape('NUAGE_NETWORK_HOST'), 'nuagenetworkhost')
+      end
+      c.filter_sensitive_data('NUAGE_NETWORK_AUTHORIZATION') { Base64.encode64("#{userid}:#{password}").chomp }
+    end
+  end
+
+  describe "targeted refresh" do
+    let(:network_group_ref)  { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }
+    let(:security_group_ref) { "02e072ef-ca95-4164-856d-3ff177b9c13c" }
+    let(:cloud_subnet_ref1)  { "d60d316a-c1ac-4412-813c-9652bdbc4e41" }
+    let(:cloud_subnet_ref2)  { "debb9f88-f252-4c30-9a17-d6ae3865e365" }
+    let(:unexisting_ref)     { "unexisting-ems-ref" }
+
+    TARGET_REFRESH_SETTINGS.each do |settings|
+      context "with settings #{settings}" do
+        before(:each) do
+          stub_settings_merge(
+            :ems_refresh => {
+              :nuage_network => settings
+            }
+          )
+        end
+
+        describe "on empty database" do
+          it "will refresh cloud_subnet" do
+            cloud_subnet = FactoryGirl.build(:cloud_subnet_nuage, :ems_ref => cloud_subnet_ref1)
+            test_targeted_refresh([cloud_subnet], 'cloud_subnet') do
+              assert_cloud_subnet_counts
+              assert_specific_cloud_subnet
+            end
+          end
+
+          it "will refresh network_group" do
+            network_group = FactoryGirl.build(:network_group_nuage, :ems_ref => network_group_ref)
+            test_targeted_refresh([network_group], 'network_group') do
+              assert_network_group_counts
+              assert_specific_network_group
+            end
+          end
+
+          it "will refresh security_group" do
+            security_group = FactoryGirl.build(:security_group_nuage, :ems_ref => security_group_ref)
+            test_targeted_refresh([security_group], 'security_group') do
+              assert_security_group_counts
+              assert_specific_security_group
+            end
+          end
+        end
+
+        describe "on populated database" do
+          context "object updated on remote server" do
+            let!(:network_group) do
+              FactoryGirl.create(:network_group_nuage, :ems_id => @ems.id, :ems_ref => network_group_ref, :name => nil)
+            end
+
+            let!(:cloud_subnet) do
+              FactoryGirl.create(:cloud_subnet_nuage, :ems_id => @ems.id, :ems_ref => cloud_subnet_ref1,
+                                 :network_group => network_group, :name => nil)
+            end
+
+            let!(:security_group) do
+              FactoryGirl.create(:security_group_nuage, :ems_id => @ems.id, :ems_ref => security_group_ref,
+                                 :network_group => network_group, :name => nil)
+            end
+
+            it "network_group is updated" do
+              test_targeted_refresh([network_group], 'network_group_is_updated') do
+                assert_fetched(network_group)
+                assert_fetched(cloud_subnet)
+                assert_fetched(security_group)
+              end
+            end
+
+            it "cloud_subnet is updated" do
+              test_targeted_refresh([cloud_subnet], 'cloud_subnet_is_updated') do
+                assert_fetched(network_group)
+                assert_fetched(cloud_subnet)
+                assert_fetched(security_group)
+              end
+            end
+
+            it "security_group is updated" do
+              test_targeted_refresh([security_group], 'security_group_is_updated') do
+                assert_fetched(network_group)
+                assert_not_fetched(cloud_subnet)
+                assert_fetched(security_group)
+              end
+            end
+          end
+
+          context "object no longer exists on remote server" do
+            it "unexisting network_group is deleted" do
+              network_group = FactoryGirl.create(:network_group_nuage, :ems_id => @ems.id, :ems_ref => unexisting_ref)
+              cloud_subnet = FactoryGirl.create(:cloud_subnet_nuage, :ems_id => @ems.id, :ems_ref => unexisting_ref, :network_group => network_group)
+              security_group = FactoryGirl.create(:security_group_nuage, :ems_id => @ems.id, :ems_ref => unexisting_ref, :network_group => network_group)
+              test_targeted_refresh([network_group], 'network_group_is_deleted', :repeat => 1) do
+                assert_deleted(network_group)
+                assert_deleted(cloud_subnet)
+                assert_deleted(security_group)
+              end
+            end
+
+            it "unexisting cloud_subnet is deleted, but related network_group and security_group updated" do
+              network_group = FactoryGirl.create(:network_group_nuage, :ems_id => @ems.id, :ems_ref => network_group_ref)
+              cloud_subnet = FactoryGirl.create(:cloud_subnet_nuage, :ems_id => @ems.id, :ems_ref => unexisting_ref, :network_group => network_group)
+              security_group = FactoryGirl.create(:security_group_nuage, :ems_id => @ems.id, :ems_ref => security_group_ref, :network_group => network_group)
+              test_targeted_refresh([cloud_subnet], 'cloud_subnet_is_deleted', :repeat => 1) do
+                assert_fetched(network_group)
+                assert_deleted(cloud_subnet)
+                assert_fetched(security_group)
+              end
+            end
+
+            it "unexisting security_group is deleted, but related network_group updated" do
+              network_group = FactoryGirl.create(:network_group_nuage, :ems_id => @ems.id, :ems_ref => network_group_ref)
+              security_group = FactoryGirl.create(:security_group_nuage, :ems_id => @ems.id, :ems_ref => unexisting_ref, :network_group => network_group)
+              test_targeted_refresh([security_group], 'security_group_is_deleted', :repeat => 1) do
+                assert_fetched(network_group)
+                assert_deleted(security_group)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_targeted_refresh(targets, cassette, repeat: 2)
+    targets = active_records_to_targets(targets)
+    repeat.times do # Run twice to verify that a second run with existing data does not change anything
+      EmsRefresh.queue_refresh(targets)
+      expect(MiqQueue.where(:method_name => 'refresh').count).to eq 1
+      refresh_job = MiqQueue.where(:method_name => 'refresh').first
+      VCR.use_cassette(described_class.name.underscore + "_targeted/" + cassette) do
+        refresh_job.deliver
+      end
+      @ems.reload
+      yield
+    end
+  end
+
+  def active_records_to_targets(targets)
+    targets.map do |target|
+      case target
+      when ManagerRefresh::Target
+        return target
+      when NetworkGroup
+        association = :network_groups
+      when CloudSubnet
+        association = :cloud_subnets
+      when SecurityGroup
+        association = :security_groups
+      end
+      ManagerRefresh::Target.new(
+        :manager     => @ems,
+        :association => association,
+        :manager_ref => {:ems_ref => target.ems_ref}
+      )
+    end
+  end
+
+  def assert_cloud_subnet_counts
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(NetworkGroup.count).to eq(1)
+    expect(SecurityGroup.count).to eq(1)
+    expect(CloudSubnet.count).to eq(1)
+    expect(FloatingIp.count).to eq(0)
+    expect(NetworkPort.count).to eq(0)
+    expect(NetworkRouter.count).to eq(0)
+  end
+
+  def assert_specific_cloud_subnet
+    s1 = CloudSubnet.find_by(:ems_ref => cloud_subnet_ref1)
+    expect(s1).to have_attributes(
+      :name                           => "Subnet 1",
+      :ems_id                         => @ems.id,
+      :availability_zone_id           => nil,
+      :cloud_network_id               => nil,
+      :cidr                           => "10.10.20.0/24",
+      :status                         => nil,
+      :dhcp_enabled                   => false,
+      :gateway                        => "10.10.20.1",
+      :network_protocol               => "ipv4",
+      :cloud_tenant_id                => nil,
+      :dns_nameservers                => nil,
+      :ipv6_router_advertisement_mode => nil,
+      :ipv6_address_mode              => nil,
+      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet",
+      :network_router_id              => nil,
+      :network_group_id               => NetworkGroup.find_by(:ems_ref => network_group_ref).id,
+      :parent_cloud_subnet_id         => nil,
+      :extra_attributes               => {
+        "enterprise_name" => "XLAB",
+        "enterprise_id"   => network_group_ref,
+        "domain_name"     => "BaseL3",
+        "domain_id"       => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
+        "zone_name"       => "Zone 1",
+        "zone_id"         => "6256954b-9dd6-43ed-94ff-9daa683ab8b0"
+      }
+    )
+  end
+
+  def assert_network_group_counts
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(NetworkGroup.count).to eq(1)
+    expect(SecurityGroup.count).to eq(1)
+    expect(CloudSubnet.count).to eq(2)
+    expect(FloatingIp.count).to eq(0)
+    expect(NetworkPort.count).to eq(0)
+    expect(NetworkRouter.count).to eq(0)
+  end
+
+  def assert_specific_network_group
+    g = NetworkGroup.find_by(:ems_ref => network_group_ref)
+    expect(g).to have_attributes(
+      :name                   => "XLAB",
+      :cidr                   => nil,
+      :status                 => "active",
+      :enabled                => nil,
+      :ems_id                 => @ems.id,
+      :orchestration_stack_id => nil,
+      :type                   => "ManageIQ::Providers::Nuage::NetworkManager::NetworkGroup"
+    )
+    expect(g.cloud_subnets.count).to eq(2)
+    expect(g.security_groups.count).to eq(1)
+
+    expect(g.cloud_subnets.map(&:ems_ref))
+      .to match_array([cloud_subnet_ref1, cloud_subnet_ref2])
+    expect(g.security_groups.map(&:ems_ref))
+      .to match_array([security_group_ref])
+  end
+
+  def assert_security_group_counts
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(NetworkGroup.count).to eq(1)
+    expect(SecurityGroup.count).to eq(1)
+    expect(CloudSubnet.count).to eq(0)
+    expect(FloatingIp.count).to eq(0)
+    expect(NetworkPort.count).to eq(0)
+    expect(NetworkRouter.count).to eq(0)
+  end
+
+  def assert_specific_security_group
+    g1 = SecurityGroup.find_by(:ems_ref => security_group_ref)
+    expect(g1).to have_attributes(
+      :name                   => "Test Policy Group",
+      :description            => nil,
+      :type                   => "ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup",
+      :ems_id                 => @ems.id,
+      :cloud_network_id       => nil,
+      :cloud_tenant_id        => nil,
+      :orchestration_stack_id => nil
+    )
+    expect(g1.network_group.ems_ref).to eq(network_group_ref)
+  end
+
+  def assert_fetched(instance)
+    instance.reload
+    expect(instance.name.to_s).not_to be_empty
+  end
+
+  def assert_not_fetched(instance)
+    instance.reload
+    expect(instance.name.to_s).to be_empty
+  end
+
+  def assert_deleted(instance)
+    expect { instance.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet.yml
@@ -1,0 +1,531 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:28
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:28 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/d60d316a-c1ac-4412-813c-9652bdbc4e41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:28
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TUW+bMBD+K5OfQ2XAOMAbLahFWqooyfYy7cHYlwbVMciYtmzaf99BSppUe5gESNx3vu/u+84/fhN5qLWyYEhqeq0XpBX443ZDCyQlvxoDZEEwULthK5spWDzuis16U24LhLTo3LdWCQfqdkAwFnxPIaCeYKryWLyMPaFi5iVScn8ZcakiuD6W44ekfkT9JU849SmlCyItCFc35gpkLJxAobDhrkM2n97gE9AbijUNuKPonjEcRNHN/E6IOI6Nb/sKc774GFEDxmpZti88m6s528OCPCHjqxgui08HoJO2bseeZqWOojYOjDASVo0aCfJym91+LXLMt03vIK87V5unvu4OYBHnURSyNIiWYTyn7IR9AnfGGA9DhF5MqXBsGvt+yNiC9EaB1WIojKg0IETKx4diU+4mrhkl6V7oDs5+uUm8U7Ndq2t3EuAiTdrhfaSrgs2rmfr9TzPLHHMVpyr0ufCkL6THmB94sR9KL+FRUKlKMmCjjqf1mk7wIOJJxCovUYp7LATlJWy/x18heByKKq5G8+DNgTVCj2dOs5TrC9fm0PvGluvvjJxS7mcn3xUA+1JLGMv4MU3iKEDJz36vsrtzScLjNGJpkaeUprdZmgVYcZ3t/q1+2+haDvfoZjvV9oMgSmKW4KK2fYXYWW8Hx1Yj3cckousaWY+3YHtAYdQjuNfGPm+ga3orLxLzh7v1BtDj0dS+u9611jZvQ7ZZn4mOvXa1xCv2qdUPutWccXcQxoBeifaCbF1+3rAO7nVTCY0yXXL/+fkXNX5HyEIEAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:28 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/6256954b-9dd6-43ed-94ff-9daa683ab8b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:28
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7TMBD9FeRzLTmN7SS97ZKItUSXqC0cWHGY2I42wnGixAEixL8z7m5ZFfbAxdK8mfc8fs8PP4l+7JyZrCc7vzi3ISNgEU7raMmOmKGHzpMNQagL61EPZ7i6P1WH+qCOFbYczOHjaCBYc7tiMwfZMrtlFLhpKM+znILJOS20lkkmpDbCXtNKPMguESzJZMHTlDG2IXqyELrBv9oEgyvP82Vnb0MP89c/JfRxy8+Dt28SvMqsiHRajd/kzTXR2FlP3RjvuUDxwcF68NruBxN1SnW8uX1flag0Lo3rdBQmuxbcbKMzelqfFYi6v6sO6nSeHb57O/2/H6rEWbkVshC8oYUxkvLUGlrwtsUSQOYpNHnDyCWjMyMTKGZtTrOt1JQXgiGj0VSCAGgkl2liYn4/gp08uMh5eqeq/3FD1c+xq/oTR5Jf+sZOH9q7YQ6z8selQaNxGgMIth8dJvOiNw7ozPpuGpYxgkkhBONsy3K0dHGh05j3Xw7BPA+6iz9gf5l4+wjeW7eH8UW5rNUV8deX3+dhcEy3AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:28 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:29
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:29 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:29
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:29 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/policygroups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:29
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:29 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:29
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:29 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:29
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet_is_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet_is_deleted.yml
@@ -1,0 +1,320 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdIC03OgCiAdYglYq9srwBF3D0WUFDRoCnf/BYs5GfjGqyCPW6PIhowshTwdhIKuHFMMOygCd3Zg+XS0eyd0YgbDI4rZe7jfWW1SUlEZmqO/X7BalrJ4pHGBF+Lb/yj5J93z0NqBZcr+4LhAAAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet_is_updated.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/cloud_subnet_is_updated.yml
@@ -1,0 +1,531 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/d60d316a-c1ac-4412-813c-9652bdbc4e41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TUW+bMBD+K5OfQ2XAOMAbLahFWqooyfYy7cHYlwbVMciYtmzaf99BSppUe5gESNx3vu/u+84/fhN5qLWyYEhqeq0XpBX443ZDCyQlvxoDZEEwULthK5spWDzuis16U24LhLTo3LdWCQfqdkAwFnxPIaCeYKryWLyMPaFi5iVScn8ZcakiuD6W44ekfkT9JU849SmlCyItCFc35gpkLJxAobDhrkM2n97gE9AbijUNuKPonjEcRNHN/E6IOI6Nb/sKc774GFEDxmpZti88m6s528OCPCHjqxgui08HoJO2bseeZqWOojYOjDASVo0aCfJym91+LXLMt03vIK87V5unvu4OYBHnURSyNIiWYTyn7IR9AnfGGA9DhF5MqXBsGvt+yNiC9EaB1WIojKg0IETKx4diU+4mrhkl6V7oDs5+uUm8U7Ndq2t3EuAiTdrhfaSrgs2rmfr9TzPLHHMVpyr0ufCkL6THmB94sR9KL+FRUKlKMmCjjqf1mk7wIOJJxCovUYp7LATlJWy/x18heByKKq5G8+DNgTVCj2dOs5TrC9fm0PvGluvvjJxS7mcn3xUA+1JLGMv4MU3iKEDJz36vsrtzScLjNGJpkaeUprdZmgVYcZ3t/q1+2+haDvfoZjvV9oMgSmKW4KK2fYXYWW8Hx1Yj3cckousaWY+3YHtAYdQjuNfGPm+ga3orLxLzh7v1BtDj0dS+u9611jZvQ7ZZn4mOvXa1xCv2qdUPutWccXcQxoBeifaCbF1+3rAO7nVTCY0yXXL/+fkXNX5HyEIEAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/6256954b-9dd6-43ed-94ff-9daa683ab8b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7TMBD9FeRzLTmN7SS97ZKItUSXqC0cWHGY2I42wnGixAEixL8z7m5ZFfbAxdK8mfc8fs8PP4l+7JyZrCc7vzi3ISNgEU7raMmOmKGHzpMNQagL61EPZ7i6P1WH+qCOFbYczOHjaCBYc7tiMwfZMrtlFLhpKM+znILJOS20lkkmpDbCXtNKPMguESzJZMHTlDG2IXqyELrBv9oEgyvP82Vnb0MP89c/JfRxy8+Dt28SvMqsiHRajd/kzTXR2FlP3RjvuUDxwcF68NruBxN1SnW8uX1flag0Lo3rdBQmuxbcbKMzelqfFYi6v6sO6nSeHb57O/2/H6rEWbkVshC8oYUxkvLUGlrwtsUSQOYpNHnDyCWjMyMTKGZtTrOt1JQXgiGj0VSCAGgkl2liYn4/gp08uMh5eqeq/3FD1c+xq/oTR5Jf+sZOH9q7YQ6z8selQaNxGgMIth8dJvOiNw7ozPpuGpYxgkkhBONsy3K0dHGh05j3Xw7BPA+6iz9gf5l4+wjeW7eH8UW5rNUV8deX3+dhcEy3AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/policygroups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group.yml
@@ -1,0 +1,657 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:30
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:30 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:30
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:30 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/subnets
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:30
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '2'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOVV226bQBD9lWqfvdHeWXhzYpQgNZFlu32p+rDsLjEKBgRLUlr137vg4NhReonUSq0qARJzZubMzgyHD1+A3uaFaWwJorIrihmolX9xm762IAKfq9KCGfCG3PVrXY3G+GYTr5arZB17qFCte1cb5aw57z0olciQJQgqZlLIZCChMpLBUGuBAy604fY0bOEfIMIc4UCEPCQIoRnQjVUur8oTkNFgBJXxBbetZ8PobH8hn7O0bqfaO28mnJ9N94io3VD4uku9z5vBYnpvy3VS34v5lM01nZ2BW8/4oPrj5HgIsK1u8nqoaerUTuWls6Uqtb2uzECwSNbz87fxwvs3VefsIm9dXt52ebu1jccF55RFAmMcTi4b1dxad8AwQoR47L5MDPCeXFDCZqArjW0K1celSgvrEZDcXMWrZDNyTSiIMlW09jAvNzZvX2xbF7nbN+DITTf945FOElYP5VjvLw4zWXhfY9M0zKSEGeEEMk0RDBUOoBHKUim4pYKDab3GCJpirIhBkCDpI0iGYUg8D0oRJ4JlNCDj8n1ytilVMcTsz5Isj6Y2mR43Nlm+Z2DvcjlN8rEDtrnPtR3SYEE5lUHA8WHe1/OLQ0ogZMRZFC8ihCJBo3jIuJxvXu5+XRW57i/9NOsxt+QcozBEgYe61GOHfju7qwtP93QS1baVzoevYL31jTE31j1Uzd3KtlXX6CPHxdXFcmX9jIehdu3prtVN9amfr5YHol1XuFz7T+xZqU9015PHxVaVpS2uVX1Etkyeb1hrL4sqVYVv0zH319nfJiAC4R8ICKMvCgh5nYDgVwkI+e0CQnhA5XcEhAlKD/qBkcSYsn9EQAQyFAsFNVYaMoYJlJhqGApOUpNqZhk+FRBBuP9jsBSGxgjIqDUwZFnmX5USkqpUpugPCYhEofQixfnPBeR8Hs3JawQEE8JDyUL0PwjIx2835wL9gwgAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:30 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/policygroups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:30
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:30 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/debb9f88-f252-4c30-9a17-d6ae3865e365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:30
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TTW+jMBD9KyufQ2UDNh+3tKAWaVNFSXYvqz0Ye9JYdQwypi272v++hpQ0qfawEiAx781745nxj99IHJSWFgzKTa/1ArXc/7jd0ALK0a/GAFogH1Bu2IpmCpaPu3Kz3lTb0kOad+5bK7kDeTt4MOVsjyHEAY9lHcRpkgZcpnGQCcFIQpmQFK7TCv9BOaGYJCyjWYgxXiBhgTvVmCswjpIJ5NIX3HXejeCb04O9pgF35N2zD4eU3szvhPDjWPi2rz3nyxiRg48pUbUvbDmrOdvDAj15x1c+XIqTMQE6YVU71jR36siVcWC4EbBq5GhQVNvl7dey8Hzb9A4K1TllnnrVHcB6nFEaxTkjhGQzZcftE7gzRjAOQ4+9mEoiz6QsCuMF6o0Eq/lQGl5r8AiqHh/KTbWbvGYU5XuuOzjPy03NOxXbtVq5UwMuaMIO70e6EmxezVTvfw6zKjxXQl1n+zQN9iENg1hEOMg4SQLJOEQpoxAxiub1mjKimhAeShyEOPUZ4Z4EWeh9cI1pyOJ9lITT8r05sIbrMed0lmp9MbU59L6x1fp7jE6U+3mS7x0A+6IEjDKERTRKk4SS87xXy7uzJGJpTuO8LHKMcxbl5ai4Xu7+3f220UoM936a7aSdUkpwluHEQ33tsXO/HRxb7e0+TsK7rhFqvAXbg2+MfAT32tjnDXRNb8UFsXi4W2/Az3gcat9d71prm7dhuVmfjY69dkr4K/ap1A+71cy4O3BjQK94e2G2rj5vWAf3uqm59m269P7z8y9py9+wQgQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:30 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/d60d316a-c1ac-4412-813c-9652bdbc4e41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:31
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TUW+bMBD+K5OfQ2XAOMAbLahFWqooyfYy7cHYlwbVMciYtmzaf99BSppUe5gESNx3vu/u+84/fhN5qLWyYEhqeq0XpBX443ZDCyQlvxoDZEEwULthK5spWDzuis16U24LhLTo3LdWCQfqdkAwFnxPIaCeYKryWLyMPaFi5iVScn8ZcakiuD6W44ekfkT9JU849SmlCyItCFc35gpkLJxAobDhrkM2n97gE9AbijUNuKPonjEcRNHN/E6IOI6Nb/sKc774GFEDxmpZti88m6s528OCPCHjqxgui08HoJO2bseeZqWOojYOjDASVo0aCfJym91+LXLMt03vIK87V5unvu4OYBHnURSyNIiWYTyn7IR9AnfGGA9DhF5MqXBsGvt+yNiC9EaB1WIojKg0IETKx4diU+4mrhkl6V7oDs5+uUm8U7Ndq2t3EuAiTdrhfaSrgs2rmfr9TzPLHHMVpyr0ufCkL6THmB94sR9KL+FRUKlKMmCjjqf1mk7wIOJJxCovUYp7LATlJWy/x18heByKKq5G8+DNgTVCj2dOs5TrC9fm0PvGluvvjJxS7mcn3xUA+1JLGMv4MU3iKEDJz36vsrtzScLjNGJpkaeUprdZmgVYcZ3t/q1+2+haDvfoZjvV9oMgSmKW4KK2fYXYWW8Hx1Yj3cckousaWY+3YHtAYdQjuNfGPm+ga3orLxLzh7v1BtDj0dS+u9611jZvQ7ZZn4mOvXa1xCv2qdUPutWccXcQxoBeifaCbF1+3rAO7nVTCY0yXXL/+fkXNX5HyEIEAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:31 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/3b11a2d0-2082-42f1-92db-0b05264f372e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:31
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7bIBT8lYpzkLCDsZ3bbm11kZqtlaQ9dNXDM2CtVQzI4LZW1X8vZDddpd1DL5aYNzM8ZvzwE4nHUctZGbQzi9Yb5CAewml1Cu2QtBOMBm1QhMawHoU9w+39qT10B35s40iDDx+dhKDk7RqHFbCBqJxgoLLHtCorDLKiuBaCZWXBhCzUtayJH7TLCpKVrKbbjBCyQWJWEEZrXh2CjCt7f9nZqDCB//rnCFPa8rM16g2JV8k1IqPg7hu7uRZK5cU8unTPBUoPDsqAEWpvZfJp+PHm9n3bRCe39HoUyRjtBtBepWTEvD47IH5/1x746cy1342a/z8P3kTuts8yyCXBOalyTPMhw3UeVaQnRc7osC3zxH3q6Kwoi2imVIXLnAlM64LgmvYCMygAekbZNpOpvx9BzQZ00jy9k3f/pMG759p594lGkVmmXs0fhjvrg+fmuPQx6MiOBQQ1OR2befFzNiazvpvt4hKYlXVFqoKmtqZFh1HEvv9KCLy3Ykx/wP7CePsIxii9B/fi3HT8Svjry2/D3gJztwIAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:31 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:31
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:31 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/6256954b-9dd6-43ed-94ff-9daa683ab8b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:31
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7TMBD9FeRzLTmN7SS97ZKItUSXqC0cWHGY2I42wnGixAEixL8z7m5ZFfbAxdK8mfc8fs8PP4l+7JyZrCc7vzi3ISNgEU7raMmOmKGHzpMNQagL61EPZ7i6P1WH+qCOFbYczOHjaCBYc7tiMwfZMrtlFLhpKM+znILJOS20lkkmpDbCXtNKPMguESzJZMHTlDG2IXqyELrBv9oEgyvP82Vnb0MP89c/JfRxy8+Dt28SvMqsiHRajd/kzTXR2FlP3RjvuUDxwcF68NruBxN1SnW8uX1flag0Lo3rdBQmuxbcbKMzelqfFYi6v6sO6nSeHb57O/2/H6rEWbkVshC8oYUxkvLUGlrwtsUSQOYpNHnDyCWjMyMTKGZtTrOt1JQXgiGj0VSCAGgkl2liYn4/gp08uMh5eqeq/3FD1c+xq/oTR5Jf+sZOH9q7YQ6z8selQaNxGgMIth8dJvOiNw7ozPpuGpYxgkkhBONsy3K0dHGh05j3Xw7BPA+6iz9gf5l4+wjeW7eH8UW5rNUV8deX3+dhcEy3AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:31 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:31
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group_is_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group_is_deleted.yml
@@ -1,0 +1,312 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/unexisting-ems-ref/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:25
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdICw1nQBSInQRLwV55HQGKcncsaNJRoCnf/BYuaFeXGmLKPe8vqhY0iBaCBry6NNBD4kbHA82Kp7QQHTvcW+cYeMchMSGzG/+nw2YtieFu3rg/LVzdKjxeaU6wWf7iH0X/Pl3PqTdUcQfX8QAAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:25 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdIC03OgCiAdYglYq9srwBF3D0WUFDRoCnf/BYs5GfjGqyCPW6PIhowshTwdhIKuHFMMOygCd3Zg+XS0eyd0YgbDI4rZe7jfWW1SUlEZmqO/X7BalrJ4pHGBF+Lb/yj5J93z0NqBZcr+4LhAAAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdICw1nQBQo6wRLwba8XkEU5e5Y0KSjQFO++a1YqA7OFqyCPR5vIhowshQwnXlYJtdm8OS4w/kETejFNVimjh61cxrxgMExU4b3gU+LNinJyV29Yn9Z0VyNPJZ0J9htf/Gvpr/PbtfUG+jCz+L1AAAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdICw1nQBSInQRLwV55HQGKcncsaNJRoCnf/BYuaFeXGmLKPe8vqhY0iBaCBry6NNBD4kbHA82Kp7QQHTvcW+cYeMchMSGzG/+nw2YtieFu3rg/LVzdKjxeaU6wWf7iH0X/Pl3PqTdUcQfX8QAAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group_is_updated.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_group_is_updated.yml
@@ -1,0 +1,657 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:23
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:23 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:23
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:23 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/subnets
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:23
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '2'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOVV226bQBD9lWqfvdHeWXhzYpQgNZFlu32p+rDsLjEKBgRLUlr137vg4NhReonUSq0qARJzZubMzgyHD1+A3uaFaWwJorIrihmolX9xm762IAKfq9KCGfCG3PVrXY3G+GYTr5arZB17qFCte1cb5aw57z0olciQJQgqZlLIZCChMpLBUGuBAy604fY0bOEfIMIc4UCEPCQIoRnQjVUur8oTkNFgBJXxBbetZ8PobH8hn7O0bqfaO28mnJ9N94io3VD4uku9z5vBYnpvy3VS34v5lM01nZ2BW8/4oPrj5HgIsK1u8nqoaerUTuWls6Uqtb2uzECwSNbz87fxwvs3VefsIm9dXt52ebu1jccF55RFAmMcTi4b1dxad8AwQoR47L5MDPCeXFDCZqArjW0K1celSgvrEZDcXMWrZDNyTSiIMlW09jAvNzZvX2xbF7nbN+DITTf945FOElYP5VjvLw4zWXhfY9M0zKSEGeEEMk0RDBUOoBHKUim4pYKDab3GCJpirIhBkCDpI0iGYUg8D0oRJ4JlNCDj8n1ytilVMcTsz5Isj6Y2mR43Nlm+Z2DvcjlN8rEDtrnPtR3SYEE5lUHA8WHe1/OLQ0ogZMRZFC8ihCJBo3jIuJxvXu5+XRW57i/9NOsxt+QcozBEgYe61GOHfju7qwtP93QS1baVzoevYL31jTE31j1Uzd3KtlXX6CPHxdXFcmX9jIehdu3prtVN9amfr5YHol1XuFz7T+xZqU9015PHxVaVpS2uVX1Etkyeb1hrL4sqVYVv0zH319nfJiAC4R8ICKMvCgh5nYDgVwkI+e0CQnhA5XcEhAlKD/qBkcSYsn9EQAQyFAsFNVYaMoYJlJhqGApOUpNqZhk+FRBBuP9jsBSGxgjIqDUwZFnmX5USkqpUpugPCYhEofQixfnPBeR8Hs3JawQEE8JDyUL0PwjIx2835wL9gwgAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:23 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d/policygroups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Page:
+      - "-1"
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Pagesize:
+      - '50'
+      X-Nuage-Count:
+      - '1'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/d60d316a-c1ac-4412-813c-9652bdbc4e41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TUW+bMBD+K5OfQ2XAOMAbLahFWqooyfYy7cHYlwbVMciYtmzaf99BSppUe5gESNx3vu/u+84/fhN5qLWyYEhqeq0XpBX443ZDCyQlvxoDZEEwULthK5spWDzuis16U24LhLTo3LdWCQfqdkAwFnxPIaCeYKryWLyMPaFi5iVScn8ZcakiuD6W44ekfkT9JU849SmlCyItCFc35gpkLJxAobDhrkM2n97gE9AbijUNuKPonjEcRNHN/E6IOI6Nb/sKc774GFEDxmpZti88m6s528OCPCHjqxgui08HoJO2bseeZqWOojYOjDASVo0aCfJym91+LXLMt03vIK87V5unvu4OYBHnURSyNIiWYTyn7IR9AnfGGA9DhF5MqXBsGvt+yNiC9EaB1WIojKg0IETKx4diU+4mrhkl6V7oDs5+uUm8U7Ndq2t3EuAiTdrhfaSrgs2rmfr9TzPLHHMVpyr0ufCkL6THmB94sR9KL+FRUKlKMmCjjqf1mk7wIOJJxCovUYp7LATlJWy/x18heByKKq5G8+DNgTVCj2dOs5TrC9fm0PvGluvvjJxS7mcn3xUA+1JLGMv4MU3iKEDJz36vsrtzScLjNGJpkaeUprdZmgVYcZ3t/q1+2+haDvfoZjvV9oMgSmKW4KK2fYXYWW8Hx1Yj3cckousaWY+3YHtAYdQjuNfGPm+ga3orLxLzh7v1BtDj0dS+u9611jZvQ7ZZn4mOvXa1xCv2qdUPutWccXcQxoBeifaCbF1+3rAO7nVTCY0yXXL/+fkXNX5HyEIEAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/subnets/debb9f88-f252-4c30-9a17-d6ae3865e365
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulSubnet'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1TTW+jMBD9KyufQ2UDNh+3tKAWaVNFSXYvqz0Ye9JYdQwypi272v++hpQ0qfawEiAx781745nxj99IHJSWFgzKTa/1ArXc/7jd0ALK0a/GAFogH1Bu2IpmCpaPu3Kz3lTb0kOad+5bK7kDeTt4MOVsjyHEAY9lHcRpkgZcpnGQCcFIQpmQFK7TCv9BOaGYJCyjWYgxXiBhgTvVmCswjpIJ5NIX3HXejeCb04O9pgF35N2zD4eU3szvhPDjWPi2rz3nyxiRg48pUbUvbDmrOdvDAj15x1c+XIqTMQE6YVU71jR36siVcWC4EbBq5GhQVNvl7dey8Hzb9A4K1TllnnrVHcB6nFEaxTkjhGQzZcftE7gzRjAOQ4+9mEoiz6QsCuMF6o0Eq/lQGl5r8AiqHh/KTbWbvGYU5XuuOzjPy03NOxXbtVq5UwMuaMIO70e6EmxezVTvfw6zKjxXQl1n+zQN9iENg1hEOMg4SQLJOEQpoxAxiub1mjKimhAeShyEOPUZ4Z4EWeh9cI1pyOJ9lITT8r05sIbrMed0lmp9MbU59L6x1fp7jE6U+3mS7x0A+6IEjDKERTRKk4SS87xXy7uzJGJpTuO8LHKMcxbl5ai4Xu7+3f220UoM936a7aSdUkpwluHEQ33tsXO/HRxb7e0+TsK7rhFqvAXbg2+MfAT32tjnDXRNb8UFsXi4W2/Az3gcat9d71prm7dhuVmfjY69dkr4K/ap1A+71cy4O3BjQK94e2G2rj5vWAf3uqm59m269P7z8y9py9+wQgQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/6256954b-9dd6-43ed-94ff-9daa683ab8b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7TMBD9FeRzLTmN7SS97ZKItUSXqC0cWHGY2I42wnGixAEixL8z7m5ZFfbAxdK8mfc8fs8PP4l+7JyZrCc7vzi3ISNgEU7raMmOmKGHzpMNQagL61EPZ7i6P1WH+qCOFbYczOHjaCBYc7tiMwfZMrtlFLhpKM+znILJOS20lkkmpDbCXtNKPMguESzJZMHTlDG2IXqyELrBv9oEgyvP82Vnb0MP89c/JfRxy8+Dt28SvMqsiHRajd/kzTXR2FlP3RjvuUDxwcF68NruBxN1SnW8uX1flag0Lo3rdBQmuxbcbKMzelqfFYi6v6sO6nSeHb57O/2/H6rEWbkVshC8oYUxkvLUGlrwtsUSQOYpNHnDyCWjMyMTKGZtTrOt1JQXgiGj0VSCAGgkl2liYn4/gp08uMh5eqeq/3FD1c+xq/oTR5Jf+sZOH9q7YQ6z8selQaNxGgMIth8dJvOiNw7ozPpuGpYxgkkhBONsy3K0dHGh05j3Xw7BPA+6iz9gf5l4+wjeW7eH8UW5rNUV8deX3+dhcEy3AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/zones/3b11a2d0-2082-42f1-92db-0b05264f372e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1SwY7bIBT8lYpzkLCDsZ3bbm11kZqtlaQ9dNXDM2CtVQzI4LZW1X8vZDddpd1DL5aYNzM8ZvzwE4nHUctZGbQzi9Yb5CAewml1Cu2QtBOMBm1QhMawHoU9w+39qT10B35s40iDDx+dhKDk7RqHFbCBqJxgoLLHtCorDLKiuBaCZWXBhCzUtayJH7TLCpKVrKbbjBCyQWJWEEZrXh2CjCt7f9nZqDCB//rnCFPa8rM16g2JV8k1IqPg7hu7uRZK5cU8unTPBUoPDsqAEWpvZfJp+PHm9n3bRCe39HoUyRjtBtBepWTEvD47IH5/1x746cy1342a/z8P3kTuts8yyCXBOalyTPMhw3UeVaQnRc7osC3zxH3q6Kwoi2imVIXLnAlM64LgmvYCMygAekbZNpOpvx9BzQZ00jy9k3f/pMG759p594lGkVmmXs0fhjvrg+fmuPQx6MiOBQQ1OR2befFzNiazvpvt4hKYlXVFqoKmtqZFh1HEvv9KCLy3Ykx/wP7CePsIxii9B/fi3HT8Svjry2/D3gJztwIAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Nuage-Filtertype:
+      - predicate
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Filtertype:
+      - predicate
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      X-Nuage-Filter:
+      - name ISNOT 'BackHaulZone'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group.yml
@@ -1,0 +1,231 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:27
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:27 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:27
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:27 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:28
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:28 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:28
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group_is_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group_is_deleted.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKWOOw7CQAxEr2K5JhdICw1nQBQo6wRLwba8XkEU5e5Y0KSjQFO++a1YqA7OFqyCPR5vIhowshQwnXlYJtdm8OS4w/kETejFNVimjh61cxrxgMExU4b3gU+LNinJyV29Yn9Z0VyNPJZ0J9htf/Gvpr/PbtfUG+jCz+L1AAAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:24 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:42:24
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:42:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:42:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group_is_updated.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/security_group_is_updated.yml
@@ -1,0 +1,231 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAF2QQW/iMBCF/4vPWDLBsRNOCyQHtFVAhZW2qqrV2J5oLZkksk0Lqvrf1xRIq73YmjeeN+/z8ztprQ+xgQOSOfn9sFiSCXEwKr8C+qQc03VTTg5UUvAA1t3KH67X4P72IabGoVfWYXM8qDQ5747OTcgAIbz13txr37uL1Wq3fdxs9he3LqIfvA1425JaSYZXiOD35wHvk1elSsddcVZjF3AFA6TFNloMZP5M6mb1+LTdrzfNn7pZLB/qirxMSIgQbYhWh7oD5TAlasEFvHbCflctd+hf0S+M8RiSExnZ5jzjWQrVuv5t1TuHOtq++98HT4mkA7ceYRObjeed7r8o1lUyzo3WshUZlYozyqeypMq0Lc2EarEoUbGMp3WL7fonnj/fc55hYSgTqqRc85yWctZSbsqZMSA403J8X58G69PUNGcFZ1OZcybK7//8GUEKxoWQM2oYAuUgJFUCUoQiK8s8a1kxvRCPTNUV4OPlH8ymYxw4AgAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/02e072ef-ca95-4164-856d-3ff177b9c13c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:26
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE+L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7VwfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOWcYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLXDFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:26 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/75ad8ee8-726c-4950-94bc-6a5aab64631d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:27
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVU226cMBD9F57XEgaMIW97Uxspm66yadSqqqrBHrJWvICMabuq+u8dsyHJRqmqviDsOXM5Z8bz5Vek9sZqh0100QzWzqIO6OBvjx1GFxH9oeuc6TGahYPxx51qR9P6+nZ9s7253K3JZKH3HzsNHvXiSMYsrYsiL2qWVYqzTCaKlZqXTKSpVrWqOGJ87raiT3TBRcxlXuYxj+N4FimH4E3bnBmzJBuNrh08rkzvTXM/mH6PjhLnQqTZRcZlnESPkFtw9+ifbDyVJSdbA4dAYwE9XqV01tgrZ7qQbpLiAIb4N9Ao3LQ6oFeXu/niar0K+L3qdui+o5tr0q/vsZ/8hkajs3BcN1BZ1Od+XWuNOi730NzjzoMfntwqUA/vYbA3fycmCh54nSFf8RNJKooXmLvry1XQTvAilWIWgaaSPXV06Qw118CU3hy61vm3Qk6S4c9/Ihrljo8aviRtWwV2vptStT+akVQBeR1jEjPIdMWyQhYMdJGxUqmcS5ErLcLgBQKRFGRCLJhMcsWyUsSspOliOQiAKs/ylOtoGt/RA+OCl1meMZQ1eUAqWZWUQMdEg6xESQlGViRDAzb4nMrrqa1GYbiQPJZxKXlJwzj0vj2gG+WkCcxm0er9crvAPXw3baCz/HC9+7gJ7yEYzobjObRqGw3u+FeEhQrHWlLBRUFDOFhvFD2Uc0W389s3xwv6vlUmvChCbKDrTgWfYj8bN1PUMIgNWkK+4O8derUPoWuwPc4iPwTQ41K4+3Q1v6ZU6+Vmu2yHhirjBMFDZyn0qVmViGXNY5arnJaA0CUr0wSYrNIURMYxT07jMq2X/2nY0FnTPGwd1ki9VqEk2kOb+c3nb7s19WBFfwS7t20F4xOhd/Sk1SMhi/DwxvVqe/nqtaI7GE+CzdXLzfAs5OLdduva2lh81o/uXgfWbVgmY1uljIt0urkjKcNt/PvrH+W8N9iMBQAA
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:27 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/enterprises/e0819464-e7fc-4a37-b29a-e72da7b5956c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.0p0
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjo1ZDQ0MmU4ZC0wNmI5LTRjNDUtOTczZi00ZDkzZGRhNjQwYzc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Tue, 17-Oct-2017 13:40:27
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Wed, 18 Oct 2017 13:40:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAG1Ty27bMBD8F51DgJRIiczNsd3UqNM6cVoUCHpYkstUgCIalJTULfrvXclx8zxQgIa7w5l93PzJ3M+68Qnb7LQdmuYk2wH99Nf7HR4R+q37/dbFEcqWn6+XV5ur1XaZnWQNdP3XnYce/dmeLmURtC51YNI6wWSVO2a8MEwVhXfBWYHIX6Yt6JOdCsVFVeaVkpzzk8wlhL6O7buXLdyNOr6vZ2dE5bFzqd6N0Ue9cA89pOcODgixwREJTaQX2tvVprsc4oiLkfsZ/LVDn50SBk0TH67T0JHaDzE9QPIUMScPXXbapwEfQ2b+HlqH/vLLdh7bUN8OCQ6yngW9oUAiuclm5GR0M6ezoDPW9gOdczofsx+PyedUjgfYX0ALt3hHbTlSYwu2wdlu19RuenODKcR0N+p5L9ql/VSxp7uL6MeiLlbb2dl6OUpoooNmtj0WzNduzIC0/4apm2zl73g68BxS4kOLiUg1lIFjzhlIb5nUlWbgtWTGuVJUqnReIT24WlAsci2MLCXDKjgmoaiYzQ3Qb+6hsspQeHYc0jHjcUR/9ZhaaJ4QR/2Kd5hGhFrLJRX243yzRuhw1VL0PTRkQU7jjWmX6g43KYa6wUmI0CGXKA3znGsmDZIQKy2zXkkdhLJYahKS0GF9jxdD09dzmup13U2yMlUgBIeCofElk1wGZkunWaiMKZWlXagU5XfY+rfJwiplPRSswIrWiGukipEMazltETopNVAyjU909bhF5ykOu0+4X/5v7XMv2uQFB3q84IIzSRTMWJsz0BJKKIIL/CXd8n9JtuiGRNs/8XiOZF4WDIoiZ7LIDbPCeSZKlwsnFficv+AhRVuqNKaL2NZ9nJqR2VJKVRWCVZVRTOYcGLhSMZFTaQ360kzm1ovZZjnNNa1hgKbDAzYb+p8x1b+nOX8dcHb+Kufvj39lBvaW4wQAAA==
+    http_version: 
+  recorded_at: Wed, 18 Oct 2017 13:40:27 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we implement targeted refresh for NetworkManager. Following targets are supported, together with inferred co-targets:

```
TARGET           INFERS
-----------------------------------------------
NetworkGroup  -> cloud_subnets, security_groups
SecurityGroup -> network_group
CloudSubnet   -> network_group, security_groups
```

Read the table above like this: "When targeted refresh for NetworkGroup is triggered, also corresponding CloudSubnets and SecurityGroups get updated"... All three cases are tested in targeted_refresh_spec.rb.

To implement targeted refresh we had to slightly modify the existing parser so that we are able to share it for both graph refresh and targeted refresh.

@miq-bot add_label enhancement
@miq-bot assign @Ladas 

/cc @gberginc @gasper-vrhovsek