### PR TITLE
Lock qpid version to 0.18.0

### DIFF
--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -20,7 +20,7 @@ sudo apt-get install -y swig
 
 # Get the latest Qpid Proton source
 cd $HOME/build
-git clone https://github.com/apache/qpid-proton.git
+git clone --branch 0.18.0-rc1 https://github.com/apache/qpid-proton.git
 cd qpid-proton
 
 # There is a strange dependency on JSON that we need to change to version of


### PR DESCRIPTION
With this commit we make sure that qpid source is cloned at appropriate tag. For some reason the tag name is "0.18.0-rc1" which suggests that it's only a release candidate, but since version 0.19.0 is already out, we're quite certain that this tag actually points to the final implementation of 0.18.0.

---

EXPLANATION: It is most amusing that it happened yesterday only **two hours** after the qpid_install.sh was [merged](https://github.com/ManageIQ/manageiq-providers-nuage/pull/19) that the qpid 0.19.0 was released and only then they provided [tags for 0.18.0](https://github.com/apache/qpid-proton/tags). Therefore we were unable to specify the tag earlier.

---

We're sorry for all the confusion regarding qpid installation, hopefully this PR will eventually bring peace 😃 

@miq-bot add_label bug,test
@miq-bot assign @Fryguy 

/cc @chessbyte @gberginc 