### PR TITLE
Install qpid_proton gem from core Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
+  - BUNDLE_WITH=qpid_proton
 addons:
   postgresql: '9.4'
 before_install: bin/qpid_install.sh

--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# Ensure correct Ruby environment is used.
-. ~/.rvm/scripts/rvm
-rvm use $TRAVIS_RUBY_VERSION
-
-# We have to extract the major and minor ruby versions so that we can set proper GEM_HOME
-ruby_version=`echo $TRAVIS_RUBY_VERSION | egrep -o '[[:digit:]]\.[[:digit:]]'`
-
-# As we are installing the Gem built from source, we have to set the proper
-# GEM_HOME. This will ensure that the gem will be installed in a place where it
-# will be picked by bundler.
-export GEM_HOME=/home/travis/build/ManageIQ/manageiq-providers-nuage/vendor/bundle/ruby/$ruby_version.0
-
 # Install the dev dependencies for building Qpid proton system library.
 sudo apt-get install -y gcc cmake cmake-curses-gui uuid-dev
 sudo apt-get install -y libssl-dev
@@ -23,20 +11,13 @@ cd $HOME/build
 git clone --branch 0.18.0-rc1 https://github.com/apache/qpid-proton.git
 cd qpid-proton
 
-# There is a strange dependency on JSON that we need to change to version of
-# at least 2; otherwise there will be a conflict.
-sed -i .bak -e 's/ 0/ 2/' proton-c/bindings/ruby/qpid_proton.gemspec.in
-
 # Configure the source of Qpid Proton.
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/pkg -DSYSINSTALL_BINDINGS=OFF
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_BINDINGS= -DSYSINSTALL_BINDINGS=OFF
 
-# Make system libraries and the gem.
+# Compile system libraries.
 make all
 
 # Install system libraries
-make install
-
-# Manually install the Ruby Gem. This will be installed inside $GEM_HOME directory.
-gem install proton-c/bindings/ruby/qpid_proton-0.18.0.gem -- --with-qpid-proton-lib=$HOME/pkg/lib --with-qpid-proton-include=$HOME/pkg/include/
+sudo make install


### PR DESCRIPTION
Previously, the gem was installed directly from the source. However,
since the `qpid_proton` gem has been incorporated as optional in the
core `Gemfile` it is now also possible to use that gem directly by
setting the environment variable `BUNDLE_WITH=qpid_proton`.

This patch updates Travis to use the gem from `Gemfile`.