### PR TITLE
Use qpid_proton from rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
-  - BUNDLE_WITH=qpid_proton
 addons:
   postgresql: '9.4'
 before_install: bin/qpid_install.sh

--- a/manageiq-providers-nuage.gemspec
+++ b/manageiq-providers-nuage.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "excon",       "~>0.40"
+  s.add_runtime_dependency "qpid_proton", "~>0.18"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Now that `qpid_proton` gem has been officially released on RubyGems, we
can remove external dependency on the temporary GitHub repository that
hosted Ruby bindings for Qpid. This requires addition of the
`qpid_proton` gem in the gemspec.