### PR TITLE
[WIP] Expose auth_url in Nuage provider as a class method

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -5,6 +5,11 @@ module ManageIQ::Providers::Nuage::ManagerMixin
     def raw_connect(auth_url, username, password)
       ManageIQ::Providers::Nuage::NetworkManager::VsdClient.new(auth_url, username, password)
     end
+
+    def auth_url(protocol, server, port, version)
+      scheme = protocol == "ssl-with-validation" ? "https" : "http"
+      "#{scheme}://#{server}:#{port}/nuage/api/#{version}"
+    end
   end
 
   def connect(options = {})
@@ -89,7 +94,6 @@ module ManageIQ::Providers::Nuage::ManagerMixin
   end
 
   def auth_url(protocol, server, port, version)
-    scheme = protocol == "ssl-with-validation" ? "https" : "http"
-    "#{scheme}://#{server}:#{port}/nuage/api/#{version}"
+    self.class.auth_url(protocol, server, port, version)
   end
 end


### PR DESCRIPTION
Because of changes in the way the validation requests are executed
in manageiq-ui-classic we have to expose the auth_url method as a
class method. This change is required for:
https://github.com/ManageIQ/manageiq-ui-classic/pull/2532

@miq-bot add_label networks