### PR TITLE
Update raw_connect to simplify validation from UI

### DIFF
--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -22,4 +22,18 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
       end.to raise_error(MiqException::MiqInvalidCredentialsError)
     end
   end
+
+  context '.auth_url' do
+    it 'builds insecure URL' do
+      expect(described_class.auth_url(nil, 'hostname', 8443, 'v5')).to eq('http://hostname:8443/nuage/api/v5')
+    end
+
+    it 'builds secure URL' do
+      expect(described_class.auth_url('ssl-with-validation', 'hostname', 8443, 'v5')).to eq('https://hostname:8443/nuage/api/v5')
+    end
+
+    it 'builds correct IPv6 URL' do
+      expect(described_class.auth_url('ssl-with-validation', '::1', 8443, 'v5')).to eq('https://[::1]:8443/nuage/api/v5')
+    end
+  end
 end


### PR DESCRIPTION
The UI repo has changed the way endpoint validation occurs, causing a
problem withinin the angular controller when creating the arguments for
`raw_connect`. Previously, the `auth_url` was required as an argument
which mandated the need to expose the `auth_url` from the Nuage manager
so that it could be used in the UI controller.

Instead, this patch replaces `auth_url` with the specific arguments that
are needed to build the `auth_url` so that the UI can directly pass
those values into the manager.
