### PR TITLE
Enable Nuage network manager

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,8 @@
   :nuage_network:
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
+:product:
+  :nuage: true
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
Prior to this patch, the UI could not show the option to create new
network managers because these are typically created along with cloud
manager. Nuage is a dedicated SDN requiring ability to add the provider
manually.

The UI depends on the `product.nuage` setting to enable the network
providers which this patch adds directly into the Nuage.

@miq-bot assign @blomquisg 

@miq-bot add_label enhancement