### PR TITLE
Fix Nuage api_version

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -8,7 +8,8 @@ module ManageIQ::Providers::Nuage::ManagerMixin
       api_port    = endpoint_opts[:api_port]
       # In case API port is represented as a string, ensure it has no whitespaces.
       api_port.strip! if api_port.kind_of?(String)
-      api_version = endpoint_opts[:api_version].strip
+      # v5_0 is the default API version unless it is given in the opts.
+      api_version = endpoint_opts[:api_version] ? endpoint_opts[:api_version].strip : 'v5_0'
 
       url = auth_url(protocol, hostname, api_port, api_version)
       _log.info("Connecting to Nuage VSD with url #{url}")

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -13,13 +13,19 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
     end
 
     it 'connects over insecure channel' do
-      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("http://host:8000/nuage/api/", "testuser", "secret")
+      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("http://host:8000/nuage/api/v5_0", "testuser", "secret")
       @ems.connect
     end
 
     it 'connects over secure channel' do
       @ems.security_protocol = 'ssl-with-validation'
-      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("https://host:8000/nuage/api/", "testuser", "secret")
+      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("https://host:8000/nuage/api/v5_0", "testuser", "secret")
+      @ems.connect
+    end
+
+    it 'uses correct API version' do
+      @ems.api_version = 'v4_0'
+      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("http://host:8000/nuage/api/v4_0", "testuser", "secret")
       @ems.connect
     end
   end


### PR DESCRIPTION
Previously it was possible to pass an empty API version causing the
provider to fail. This patch updates the provider to set the default API
version to the latest version (v5_0), which is also the first one going
to be supported by this provider. Specs are updated to address this
change.

@miq-bot add_label bug