### PR TITLE
[WIP] Batch collecting of Nuage events with qpid sleeping

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -14,9 +14,9 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
 
   # Start monitoring for events. This method blocks forever until stop_event_monitor is called.
   def monitor_events
-    event_monitor_handle.start do |event|
+    event_monitor_handle.start_batch do |events|
       event_monitor_running
-      @queue.enq(event)
+      @queue.enq(events)
     end
   ensure
     stop_event_monitor

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -23,16 +23,22 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
     require 'qpid_proton'
 
     @options = options
+    @thread  = nil
+    @batch   = Queue.new # thread-safe implementation of Array
   end
 
-  def start(&message_handler_block)
+  def start_batch
     _log.debug("#{self.class.log_prefix} Opening amqp connection using options #{@options}")
-    @options[:message_handler_block] = message_handler_block if message_handler_block
-    connection.run
+    @options[:message_handler_block] = ->(event) { @batch << event }
+    @thread = qpid_thread
+    while @thread.alive? || !@batch.empty?
+      sleep_poll_normal
+      yield current_batch unless @batch.empty?
+    end
   end
 
   def stop
-    @handler.stop
+    @thread.exit if @thread && @thread.alive?
   end
 
   def connection
@@ -41,5 +47,40 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
       @connection = Qpid::Proton::Reactor::Container.new(@handler)
     end
     @connection
+  end
+
+  private
+
+  def current_batch
+    Array.new(@batch.size) { @batch.pop }
+  end
+
+  def sleep_poll_normal
+    sleep(self.class.parent.worker_settings[:poll])
+  end
+
+  #
+  # A simple thread `Thread.new { connection.run }` should normally be returned here.
+  # But doing so we measure a huge performance drop: events are fetched from AMQP immediately,
+  # but their processing is delayed for ~10min, which is horrible. It seems to be a problem
+  # with qpid somehow eating resources of the main thread. A quick workaround for now is to
+  # periodically pause qpid thread for a few seconds to let the main process access the resources.
+  #
+  def qpid_thread
+    t_interval = self.class.parent.worker_settings[:qpid_rest_interval]
+    t_sleep = self.class.parent.worker_settings[:qpid_rest_time]
+    Thread.new do
+      loop do
+        begin
+          Timeout.timeout(t_interval) { connection.run }
+        rescue Timeout::Error
+        rescue StandardError => e
+          _log.error("Qpid thread error: #{e}")
+          break
+        end
+        @handler.stop
+        sleep(t_sleep)
+      end
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,6 @@
       :event_catcher_nuage_network:
         :topics:
           - topic/CNAMessages
+        :poll: 15.seconds
+        :qpid_rest_interval: 15.seconds
+        :qpid_rest_time: 15.seconds

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher_spec.rb
@@ -6,4 +6,55 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher do
   it 'settings_name' do
     expect(described_class.settings_name).to eq(:event_catcher_nuage_network)
   end
+
+  describe 'stream' do
+    describe 'start_batch' do
+      before(:each) do
+        allow(stream).to receive(:connection).and_return(connection)
+        allow(stream).to receive(:sleep_poll_normal)
+        @batches = []
+      end
+
+      let!(:stream)     { described_class::Stream.new }
+      let!(:connection) { double }
+      let(:burst1)      { %w(event1 event2) }
+      let(:burst2)      { %w(event3 event4) }
+
+      it 'burst should give single batch' do
+        mock_event_bursts([burst1]) do
+          stream.start_batch { |batch| collect_batches(batch) }
+        end
+        assert_thread_stopped
+        expect(@batches).to eq([burst1])
+      end
+
+      it 'two consequent bursts should give two batches' do
+        mock_event_bursts([burst1, burst2]) do
+          print "got burst\n"
+          stream.start_batch { |batch| collect_batches(batch) }
+        end
+        assert_thread_stopped
+        expect(@batches).to eq([burst1, burst2])
+      end
+    end
+  end
+
+  def mock_event_bursts(bursts)
+    bursts.each do |burst|
+      allow(connection).to receive(:run) do
+        burst.each do |event|
+          stream.instance_variable_get(:@options)[:message_handler_block].call(event)
+        end
+      end
+      yield
+    end
+  end
+
+  def collect_batches(batch)
+    @batches << batch
+  end
+
+  def assert_thread_stopped
+    expect(stream.instance_variable_get(:@thread).alive?).to eq(false)
+  end
 end


### PR DESCRIPTION
With this commit we force periodic interrupts to the EventCatcher
thread because the gem for accessing the AMQP queue seems to consume
all EventCatcher thread resources otherwise. By default we now interrupt
the qpid gem every 15 seconds and let it sleep for 15 seconds. While
the qpid thread is sleeping, the EventProcessing thread has enough
resources to quickly process events that were captured so far.

It is not clear at the moment why resources are not distributed equally
among the threads - could be a leak in amqp_proton or in MIQ. Below please
find description of old and new event catcher behavior:

--- OLD BEHAVIOR ---
Events were reported immediately by qpid_proton gem, but they didn't get
processed by ManageIQ::Providers::Nuage::NetworkManager::EventParser for quite
a while then. Since events were being continously collected in the queue and
EventParser didn't have resources to process them the delay was increasing.
Soon after MIQ boot the delay between receiveing event and processing event
was as huge as 10 min.

--- NEW BEHAVIOR ---
Events are reported while the qpid thread is running and they are all processed
instantly when the qpid thread is put to sleep. So each event gets processed
in about 15 seconds, which is acceptable.

@miq-bot add_label enhancement
@miq-bot assign @juliancheal 
/cc @gberginc @gasper-vrhovsek 