### PR TITLE
Human readable error when selecting wrong security protocol

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -35,6 +35,8 @@ module ManageIQ::Providers::Nuage::ManagerMixin
         MiqException::MiqHostError.new("Socket error: #{err.message}")
       when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
         err
+      when Net::HTTPBadResponse
+        MiqException::MiqEVMLoginError.new("Login failed due to a bad security protocol, hostname or port.")
       else
         MiqException::MiqEVMLoginError.new("Unexpected response returned from system: #{err.message}")
       end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -113,6 +113,12 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
       allow(@ems).to receive(:with_provider_connection).and_raise(exception)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /invalid host/)
     end
+
+    it 'handles Net::HTTPBadResponse' do
+      exception = Net::HTTPBadResponse.new
+      allow(@ems).to receive(:with_provider_connection).and_raise(exception)
+      expect { @ems.verify_credentials }.to raise_error(MiqException::MiqEVMLoginError, /Login failed due to a bad security protocol, hostname or port./)
+    end
   end
 
   context '#authentications_to_validate' do


### PR DESCRIPTION
This change modifies the error message returned from nuage when selecting
the wrong security protocol. The old error message was:
```
wrong status line: "\x15\x03\x03\x00\x02\x02"
``` 
which was not informative to the end user.

@miq-bot bug

/cc @miha-plesko @gberginc 