### PR TITLE
Fix protocol selection when adding a new nuage provider

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers::Nuage::ManagerMixin
     end
 
     def auth_url(protocol, server, port, version)
-      scheme = protocol == "ssl-with-validation" ? "https" : "http"
+      scheme = %w(ssl ssl-with-validation).include?(protocol) ? "https" : "http"
       URI::Generic.build(:scheme => scheme, :host => server, :port => port, :path => "/nuage/api/#{version}").to_s
     end
   end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -17,6 +17,12 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
       @ems.connect
     end
 
+    it 'connects over secure channel without validation' do
+      @ems.security_protocol = 'ssl'
+      expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("https://host:8000/nuage/api/v5_0", "testuser", "secret")
+      @ems.connect
+    end
+
     it 'connects over secure channel' do
       @ems.security_protocol = 'ssl-with-validation'
       expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient).to receive(:new).with("https://host:8000/nuage/api/v5_0", "testuser", "secret")
@@ -142,6 +148,10 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
   context '.auth_url' do
     it 'builds insecure URL' do
       expect(described_class.auth_url(nil, 'hostname', 8443, 'v5')).to eq('http://hostname:8443/nuage/api/v5')
+    end
+
+    it 'builds insecure ssl URL' do
+      expect(described_class.auth_url('ssl', 'hostname', 8443, 'v5')).to eq('https://hostname:8443/nuage/api/v5')
     end
 
     it 'builds secure URL' do


### PR DESCRIPTION
This fixes endpoint url generation from form input values. Before, if SSL was selected, the url began
with 'http'. Now when either 'SSL' or 'SSL with validation' are selected, the url begins with 'https'.

@miq-bot add_label bug

/cc @gberginc 
/cc @miha-plesko 