### PR TITLE
[WIP] Fix delay of event processing by terminating qpid connection

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
@@ -33,7 +33,11 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler
   end
 
   def on_message(event)
-    @message_handler_block.call(JSON.parse(event.message.body)) if @message_handler_block
+    @message_handler_block&.call(JSON.parse(event.message.body))
+
+    if event.receiver.queued.zero? && event.receiver.drained.zero?
+      event.connection.close
+    end
   end
 
   def stop


### PR DESCRIPTION
This fix will terminate event connection every time when there are
no queued events in the event receiver and the receiver is drained.

@miq-bot add_label wip

/cc @miha-plesko @gberginc 