### PR TITLE
Url encode Nuage credentials

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -95,7 +95,7 @@ module ManageIQ::Providers::Nuage::ManagerMixin
 
     amqp_endpoints.map do |e|
       url = "#{e.hostname}:#{e.port}"
-      url = "#{amqp_auth.userid}:#{amqp_auth.password}@#{url}" if amqp_auth
+      url = "#{ERB::Util.url_encode(amqp_auth.userid)}:#{ERB::Util.url_encode(amqp_auth.password)}@#{url}" if amqp_auth
       url
     end
   end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -73,6 +73,21 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
         expect { @ems.verify_credentials(:amqp) }.to raise_error(StandardError)
       end
     end
+
+    context 'credentials encoding' do
+      before do
+        creds = {}
+        creds[:amqp] = {:userid => "amqp_user@!$&", :password => "amqp_password@!$&"}
+        @ems.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'amqp_hostname', :port => '5672')
+        @ems.update_authentication(creds, :save => false)
+      end
+
+      it 'encodes username and password' do
+        opts = @ems.event_monitor_options
+        hostname = opts[:urls].first
+        expect(hostname).to eq('amqp_user%40%21%24%26:amqp_password%40%21%24%26@amqp_hostname:5672')
+      end
+    end
   end
 
   context 'translate_exception' do


### PR DESCRIPTION
Encode username and password to avoid errors when using special characters such as `@` inside username and/or password. Because the amqp endpoint is generated as:
`[userid]:[password]@[amqp.endpoint.url]`

When, for instance, password contained `@` it got generated as something like:

`userid:p@ssword@amqp.endpoint.url`

which caused the validate call to get stuck in an infinite loop.

@miq-bot add_label bug

/cc @gberginc @miha-plesko 