### PR TITLE
Improve the performance of event catcher

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
     event_monitor_handle.start do |event|
       event_monitor_running
       @queue.enq(event)
+      sleep_poll_normal
     end
   ensure
     stop_event_monitor

--- a/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
@@ -1,10 +1,14 @@
 module ManageIQ::Providers::Nuage::NetworkManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_type = "#{event['entityType']}_#{event['type'].downcase}"
+    # Nuage pushes several events with the same eventReceivedTime causing
+    # EmsEvent to ignore some of them because of the same primary key. Here we
+    # just add several millisecconds to the event.
+    time = event["eventReceivedTime"] + Time.now.usec / 1000
     {
       :source     => "NUAGE",
       :event_type => event_type,
-      :timestamp  => DateTime.strptime((event["eventReceivedTime"] / 1000).to_s, '%s').to_s,
+      :timestamp  => DateTime.strptime(time.to_s, '%Q').strftime('%F %T.%6N'),
       :message    => event_type,
       :vm_ems_ref => nil,
       :full_data  => event.to_hash,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@
       :event_catcher_nuage_network:
         :topics:
           - topic/CNAMessages
+        :poll: 1.seconds


### PR DESCRIPTION
Nuage event catcher relies on Qpid Proton to get the events from the
AMQP queue. Due to synchronization issues, this resulted in massive
delays when processing events.

This patch tries to overcome this by adding a short sleep cycle to allow
the stream (Qpid) and event catcher to work together on the events.

It also resolves an issue with the fact the Nuage events are sometimes
sent with the same timestamp for certain event types, even though the
actual payload differs. As there is no ID that could be used as an EMS
reference, we alter the timestamp slightly based on the current time.

Addresses #47.
Replaces #41 and #48. Main reason for this is that I don't want to close the connection as we are loosing events! I've also attempted to do batch processing but it's even worse. Thus, for the first improvement I would like to see this merged as it improves the performance in a way that events are published into the DB.

@miq-bot add_label events, bug

@miq-bot assign @juliancheal 

/cc @bronaghs I'd also like your comment on this one, if possible.