### PR TITLE
Return empy list instead of nil for responses with empty bodies

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -90,7 +90,7 @@ module ManageIQ::Providers
     def get_list(url)
       response = @rest_call.get("#{@server}/#{url}")
       return unless response.code == 200
-      return if response.body.empty?
+      return [] if response.body.empty?
       JSON.parse(response.body)
     end
 

--- a/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
+++ b/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
@@ -15,17 +15,17 @@ describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
     let(:response_empty)    { double('Response', :code => 200, :body => '') }
     let(:response_simplest) { double('Response', :code => 200, :body => '[]') }
 
-    it "response code not 200" do
+    it "response code not 200 should return nil" do
       response(response_404)
       expect(client.send(:get_list, 'some-url')).to be_nil
     end
 
-    it "response body empty" do
+    it "response body empty should return empty list" do
       response(response_empty)
-      expect(client.send(:get_list, 'some-url')).to be_nil
+      expect(client.send(:get_list, 'some-url')).to eq([])
     end
 
-    it "response body empty list" do
+    it "response body empty list should return empty list" do
       response(response_simplest)
       expect(client.send(:get_list, 'some-url')).to eq([])
     end


### PR DESCRIPTION
vsd_client returned nil when receiving a response with empty body.
This caused a NoMethodError when calling each on nil down the line.
Now for all 200 responses with empty bodies vsd_client will return `[]`.

The issue is described here: https://bugzilla.redhat.com/show_bug.cgi?id=1527207 

/cc @miha-plesko @gberginc 
@miq-bot add_label bug
@miq-bot add_label gaprindashvili/yes, fine/yes