### PR TITLE
[WIP] Create event monitor only when amqp endpoints are defined

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -22,6 +22,15 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
     stop_event_monitor
   end
 
+  def do_work_loop
+    super if amqp?
+  end
+
+  def start_event_monitor
+    tid = super if amqp?
+    return tid unless tid.nil?
+  end
+
   def stop_event_monitor
     @event_monitor_handle.try!(:stop)
   ensure
@@ -31,5 +40,9 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
   def queue_event(event)
     event_hash = ManageIQ::Providers::Nuage::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
+  def amqp?
+    @ems.event_monitor_options[:urls].any?
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
@@ -1,0 +1,34 @@
+describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner do
+  context 'EMS without AMQP credentials' do
+    before do
+      @ems = FactoryGirl.build(:ems_nuage_network, :hostname => "host", :ipaddress => "::1")
+      @creds = {:amqp => {:userid => "amqp_user", :password => "amqp_pass"}}
+      @ems.update_authentication(@creds, :save => false)
+
+      allow_any_instance_of(described_class).to receive(:initialize)
+      @rr = described_class.new
+      @rr.instance_variable_set(:@ems, @ems)
+    end
+
+    it 'should have falsey amqp?' do
+      expect(@rr.amqp?).to be_falsey
+    end
+  end
+
+  context 'EMS with AMQP credentials' do
+    before do
+      @ems = FactoryGirl.build(:ems_nuage_network, :hostname => "host", :ipaddress => "::1")
+      @creds = {:amqp => {:userid => "amqp_user", :password => "amqp_pass"}}
+      @ems.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'amqp_hostname', :port => '5672')
+      @ems.update_authentication(@creds, :save => false)
+
+      allow_any_instance_of(described_class).to receive(:initialize)
+      @rr = described_class.new
+      @rr.instance_variable_set(:@ems, @ems)
+    end
+
+    it 'should have truthy amqp?' do
+      expect(@rr.amqp?).to be_truthy
+    end
+  end
+end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -209,4 +209,17 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
                                      'amqp_user:amqp_pass@amqp_hostname2:5672')
     end
   end
+
+  context 'no amqp endpoints defined' do
+    before(:each) do
+      @ems = FactoryGirl.build(:ems_nuage_network, :hostname => "host", :ipaddress => "::1")
+      @creds = {:amqp => {:userid => "amqp_user", :password => "amqp_pass"}}
+      @ems.update_authentication(@creds, :save => false)
+    end
+
+    it 'options without amqp urls' do
+      opts = @ems.event_monitor_options
+      expect(opts).to have_attributes(:urls => [])
+    end
+  end
 end


### PR DESCRIPTION
Ignore creating event monitor when no amqp endpoints are defined. Also a
bug when adding enpoints was fixed, where a default empty string was
added to the amqp endpoint list.

/cc @gberginc @miha-plesko 
@miq-bot add_label wip

This is linked to: https://bugzilla.redhat.com/show_bug.cgi?id=1527209