### PR TITLE
Upgrade qpid_proton related stuff to support v0.19.0

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -81,10 +81,13 @@ module ManageIQ::Providers::Nuage::ManagerMixin
 
   def event_monitor_options
     @event_monitor_options ||= begin
+      amqp_auth = authentications.detect { |a| a.authtype == 'amqp' }
       {
         :ems                       => self,
         :urls                      => amqp_urls,
         :sasl_allow_insecure_mechs => true, # Only plain (insecure) mechanism currently supported
+        :user                      => amqp_auth.userid,
+        :password                  => amqp_auth.password
       }
     end
   end
@@ -93,12 +96,8 @@ module ManageIQ::Providers::Nuage::ManagerMixin
 
   def amqp_urls
     amqp_endpoints = endpoints.select { |e| e.role == 'amqp' || e.role.start_with?('amqp_fallback') }
-    amqp_auth      = authentications.detect { |a| a.authtype == 'amqp' }
-
     amqp_endpoints.map do |e|
-      url = "#{e.hostname}:#{e.port}"
-      url = "#{ERB::Util.url_encode(amqp_auth.userid)}:#{ERB::Util.url_encode(amqp_auth.password)}@#{url}" if amqp_auth
-      url
+      "#{e.hostname}:#{e.port}"
     end
   end
 

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
@@ -1,42 +1,48 @@
-class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler < Qpid::Proton::Handler::MessagingHandler
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler < Qpid::Proton::MessagingHandler
   def initialize(options = {})
     require 'qpid_proton'
 
     super()
     @options = options
 
-    @topics = @options.delete(:topics)
-    @test_connection = @options.delete(:test_connection)
+    @topics                = @options.delete(:topics)
+    @test_connection       = @options.delete(:test_connection)
     @message_handler_block = @options.delete(:message_handler_block)
+    @url                   = @options.delete(:url)
+    @timeout               = @options.delete(:amqp_connect_timeout) || 5.seconds
   end
 
-  def on_start(event)
-    @conn = event.container.connect(@options)
+  def on_container_start(container)
+    Timeout.timeout(@timeout) { @conn = container.connect(@url, @options) }
     unless @test_connection
-      @topics.each { |topic| event.container.create_receiver(@conn, :source => "topic://#{topic}") }
+      @topics.each { |topic| @conn.open_receiver("topic://#{topic}") }
     end
+  rescue Timeout::Error
+    raise MiqException::MiqHostError, "Timeout connecting to AMQP endpoint #{@url}"
   end
 
-  def on_connection_opened(event)
+  def on_connection_open(connection)
     # In case connection test was requested, close the connection immediately.
-    event.container.stop if @test_connection
+    connection.container.stop if @test_connection
   end
 
-  def on_connection_error(_event)
+  def on_connection_error(_connection)
     raise MiqException::MiqInvalidCredentialsError, "Connection failed due to bad username or password"
   end
 
-  def on_transport_error(_event)
-    # Only raise error if single URL is used, as otherwise qpid will attempt
-    # to fallback to alternative URLs.
-    raise MiqException::MiqHostError, "Transport error" unless @options[:urls].length > 1
+  def on_transport_error(_transport)
+    raise MiqException::MiqHostError, "Transport error"
   end
 
-  def on_message(event)
-    @message_handler_block.call(JSON.parse(event.message.body)) if @message_handler_block
+  def on_message(_delivery, message)
+    @message_handler_block&.call(JSON.parse(message.body))
+  end
+
+  def on_transport_close(_transport)
+    raise MiqException::MiqHostError, "Transport closed unexpectedly"
   end
 
   def stop
-    @conn.close
+    @conn&.close
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
     unless @event_monitor_handle
       options = @ems.event_monitor_options
       options[:topics] = worker_settings[:topics]
+      options[:amqp_connect_timeout] = worker_settings[:amqp_connect_timeout]
       @event_monitor_handle = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream.new(options)
     end
     @event_monitor_handle
@@ -23,7 +24,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
   end
 
   def stop_event_monitor
-    @event_monitor_handle.try!(:stop)
+    @event_monitor_handle&.stop
   ensure
     reset_event_monitor_handle
   end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -2,17 +2,18 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   include Vmdb::Logging
 
   def self.test_amqp_connection(options = {})
+    return false if options[:urls].blank?
     # Ensure we just test the connection. AMQP channel will be established and
     # started, however it will be immediately stopped.
     options[:test_connection] = true
-    begin
-      stream = new(options)
+
+    stream = new(options)
+    ok = stream.with_fallback_urls(options[:urls]) do
       stream.connection.run
-      true
-    rescue => e
-      _log.info("#{log_prefix} Failed connecting to ActiveMQ: #{e.message}")
-      raise
+      return true
     end
+    raise MiqException::MiqHostError, "Could not connect to any of the #{options[:urls].count} AMQP hostnames" unless ok
+    true
   end
 
   def self.log_prefix
@@ -28,18 +29,40 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   def start(&message_handler_block)
     _log.debug("#{self.class.log_prefix} Opening amqp connection using options #{@options}")
     @options[:message_handler_block] = message_handler_block if message_handler_block
-    connection.run
+    with_fallback_urls(@options[:urls]) do
+      connection.run
+    end
   end
 
   def stop
-    @handler.stop
+    @handler&.stop
   end
 
   def connection
     unless @connection
-      @handler = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(@options)
-      @connection = Qpid::Proton::Reactor::Container.new(@handler)
+      @handler = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(@options.clone)
+      @connection = Qpid::Proton::Container.new(@handler)
     end
     @connection
+  end
+
+  def with_fallback_urls(urls)
+    urls.each_with_index do |url, idx|
+      endpoint_str = "ActiveMQ endpoint #{idx + 1}/#{@options[:urls].count} (#{url})"
+      _log.info("#{self.class.log_prefix} Connecting to #{endpoint_str}")
+      begin
+        @options[:url] = url
+        yield
+      rescue MiqException::MiqHostError, Errno::ECONNREFUSED, SocketError => err
+        _log.info("#{self.class.log_prefix} #{endpoint_str} errored: #{err}")
+        stop
+        reset_connection
+      end
+    end
+    false
+  end
+
+  def reset_connection
+    @connection = nil
   end
 end

--- a/bin/qpid_install.sh
+++ b/bin/qpid_install.sh
@@ -7,7 +7,7 @@ sudo apt-get install -y libsasl2-2 libsasl2-dev
 
 # Get the latest Qpid Proton source
 cd $HOME/build
-git clone --branch 0.18.1 https://github.com/apache/qpid-proton.git
+git clone --branch 0.19.0 https://github.com/apache/qpid-proton.git
 cd qpid-proton
 
 # Configure the source of Qpid Proton.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@
       :event_catcher_nuage_network:
         :topics:
           - topic/CNAMessages
+        :amqp_connect_timeout: 5.seconds


### PR DESCRIPTION
With this commit we adjust whatever needed to support qpid_proton version 0.19.0 instead of 0.18.1. Even if only a "minor" number has increased, the API is broken hence this commit. Most notable differences in qpid_proton API are:

- username/password can no longer be provided as part of URL, but separately
- class Qpid::Proton::Handler::MessagingHandler has been replaced with Qpid::Proton::Handler::MessagingHandler
- some handler callbacks have been renamed (on_start -> on_container_start etc.)
- some other functions have been renamed and signature has been updated
- `:urls` option is no longer supported (connection to fallback endpoint had to be implemented on MIQ level)

The reason to switch to qpid_proton 0.19.0 is that we measured huge performance issues on 0.18.1 that seem to be fixed in 0.19.0. Big thanks to @tadeboro for realizing that 0.19.0 was out and that it works better!

Fixes https://github.com/ManageIQ/manageiq-providers-nuage/issues/47
Must be merged together with: https://github.com/ManageIQ/manageiq/pull/16793

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1534440
@miq-bot assign @juliancheal 
@miq-bot add_label gaprindashvili/yes, events

/cc @gberginc @gasper-vrhovsek 
