### PR TITLE
Assign :ems_ref to the event

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
@@ -8,7 +8,8 @@ module ManageIQ::Providers::Nuage::NetworkManager::EventParser
       :message    => event_type,
       :vm_ems_ref => nil,
       :full_data  => event.to_hash,
-      :ems_id     => ems_id
+      :ems_id     => ems_id,
+      :ems_ref    => event["requestID"].presence || "random-#{SecureRandom.uuid}"
     }
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_parser_spec.rb
@@ -1,15 +1,46 @@
 describe ManageIQ::Providers::Nuage::NetworkManager::EventParser do
-  context ".event_to_hash" do
-    it "parses vm_ems_ref into event" do
-      ems = FactoryGirl.create(:ems_nuage_network)
-      message = JSON.parse(File.read(File.join(__dir__, "/event_catcher/alarm_delete.json")))
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return('11111111-2222-3333-4444-555555555555')
+  end
 
-      expect(described_class.event_to_hash(message, ems)).to include(
-        :source     => "NUAGE",
-        :vm_ems_ref => nil,
-        :event_type => 'alarm_delete',
-        :ems_id     => ems
-      )
+  let(:ems) { FactoryGirl.create(:ems_nuage_network) }
+
+  context ".event_to_hash" do
+    [
+      {
+        :name     => 'with requestID',
+        :fixture  => '/event_catcher/subnet_create.json',
+        :expected => {
+          :event_type => 'subnet_create',
+          :ems_ref    => '56e69f6e-a1fd-457f-b4c5-844cfd790153'
+        }
+      },
+      {
+        :name     => 'with null requestID',
+        :fixture  => '/event_catcher/alarm_delete.json',
+        :expected => {
+          :event_type => 'alarm_delete',
+          :ems_ref    => 'random-11111111-2222-3333-4444-555555555555'
+        }
+      },
+      {
+        :name     => 'with empty requestID',
+        :fixture  => '/event_catcher/alarm_create.json',
+        :expected => {
+          :event_type => 'alarm_create',
+          :ems_ref    => 'random-11111111-2222-3333-4444-555555555555'
+        }
+      }
+    ].each do |example|
+      it example[:name] do
+        message = JSON.parse(File.read(File.join(__dir__, example[:fixture])))
+        example[:expected][:ems_id] = ems.id
+        example[:expected][:vm_ems_ref] = nil
+        example[:expected][:source] = 'NUAGE'
+        example[:expected][:message] = example[:expected][:event_type] if example[:expected][:event_type]
+        example[:expected][:full_data] = message.to_hash
+        expect(described_class.event_to_hash(message, ems.id)).to include(example[:expected])
+      end
     end
   end
 end


### PR DESCRIPTION
With this commit we make sure that events are always created with unique ems_ref. For most of them we just grab value from the event hash, but we make up a new unique value when ID is not present in event hash to make is unique at least from this point on.

@miq-bot add_label enhancement
@miq-bot assign @bronaghs 

This is a replacement for https://github.com/ManageIQ/manageiq-providers-nuage/pull/52. There were two issues addressed in #52: the performance issue and the ID issue. The performance issue was solved by upgrading the underlying qpid_proton gem while the ID issue is solved by this PR.

/cc @gberginc 