### PR TITLE
Restart EventCatcher everytime we update provider

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -79,6 +79,10 @@ module ManageIQ::Providers::Nuage::ManagerMixin
     end
   end
 
+  def credentials_changed?
+    true
+  end
+
   def event_monitor_options
     @event_monitor_options ||= begin
       {


### PR DESCRIPTION
Prior this commit EventCatcher wasn't restarted when AMQP endpoints or fallback endpoints or port were updated, which is annoying. User had to either manually `sudo kill -9 PID` the old EventCatcher or restart the whole server.

With this commit we make sure that stop_event_monitor is called everytime when Nuage provider is updated.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1534460
@miq-bot add_label enhancement
@miq-bot assign @juliancheal 

/cc @gberginc 