### PR TITLE
Add name method

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -40,4 +40,8 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   def self.event_monitor_class
     ManageIQ::Providers::Nuage::NetworkManager::EventCatcher
   end
+
+  def name
+    self[:name]
+  end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -209,4 +209,9 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
                                      'amqp_user:amqp_pass@amqp_hostname2:5672')
     end
   end
+
+  it '.name' do
+    ems = FactoryGirl.create(:ems_nuage_network_with_authentication, :name => 'nuage')
+    expect(ems.name).to eq('nuage')
+  end
 end


### PR DESCRIPTION
With this commit we overwrite `name` method for `NetworkManager`,
since core's method uses parent's name and
Nuage's network provider has no parent.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1537547