### PR TITLE
[WIP] Don't run EventMonitor when user selects "None"

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -44,4 +44,13 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   def name
     self[:name]
   end
+
+  def worker_wanted?(worker_class)
+    case worker_class
+    when event_monitor_class.name
+      connection_configurations.amqp&.endpoint&.hostname&.present?
+    else
+      true
+    end
+  end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -203,4 +203,21 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
     ems = FactoryGirl.create(:ems_nuage_network_with_authentication, :name => 'nuage')
     expect(ems.name).to eq('nuage')
   end
+
+  describe 'worker_wanted?' do
+    let(:ems) { FactoryGirl.create(:ems_nuage_network) }
+
+    it 'without amqp' do
+      expect(ems.worker_wanted?(described_class::EventCatcher.name)).to be_falsey
+    end
+
+    it 'with amqp' do
+      ems.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'hostname')
+      expect(ems.worker_wanted?(described_class::EventCatcher.name)).to be_truthy
+    end
+
+    it 'truthy for non-handled worker class' do
+      expect(ems.worker_wanted?('worker::class')).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
With this commit we prevent Nuage EventCatcher from running (and of course crashing periodically) when user selected option "None" for eventing.

![capture](https://user-images.githubusercontent.com/8102426/35613729-2caf7c2c-066d-11e8-9223-28aacc33cc5d.PNG)


Depends on https://github.com/ManageIQ/manageiq/pull/16937
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1527209
@miq-bot add_label enhancement
@miq-bot assign @juliancheal 

/cc @bronaghs 