### PR TITLE
Add `stop_event_monitor_queue_on_change` method

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -111,4 +111,15 @@ module ManageIQ::Providers::Nuage::ManagerMixin
   def verify_amqp_credentials(_options = {})
     ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream.test_amqp_connection(event_monitor_options)
   end
+
+  def stop_event_monitor_queue_on_change
+    if event_monitor_class && !new_record? && (authentications.detect(&:changed?) || endpoints.detect(&:changed?))
+      _log.info("EMS: [#{name}], Credentials or endpoints have changed, stopping Event Monitor. It will be restarted by the WorkerMonitor.")
+      stop_event_monitor_queue
+    end
+  end
+
+  def stop_event_monitor_queue_on_credential_change
+    stop_event_monitor_queue_on_change
+  end
 end


### PR DESCRIPTION
`stop_event_monitor_queue_on_change` is now overriden for Nuage network provider so EventCatcher restarts when AMQP endpoints or fallback endpoints or port are changed.

This commit replaces https://github.com/ManageIQ/manageiq-providers-nuage/pull/60

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534460

Reference: https://github.com/ManageIQ/manageiq-providers-nuage/pull/60#issuecomment-359870507
