### PR TITLE
Redirect logs into log/nuage.log file

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,2 +1,4 @@
-# GlobalVars:
-#   AllowedVariables:
+GlobalVars:
+  AllowedVariables:
+  # Loggers
+  - $nuage_log

--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Nuage::ManagerMixin
       api_version = endpoint_opts[:api_version] ? endpoint_opts[:api_version].strip : 'v5_0'
 
       url = auth_url(protocol, hostname, api_port, api_version)
-      _log.info("Connecting to Nuage VSD with url #{url}")
+      $nuage_log.info("Connecting to Nuage VSD with url #{url}")
 
       connection_rescue_block do
         ManageIQ::Providers::Nuage::NetworkManager::VsdClient.new(url, username, password)
@@ -47,7 +47,7 @@ module ManageIQ::Providers::Nuage::ManagerMixin
     rescue => err
       miq_exception = translate_exception(err)
 
-      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      $nuage_log.error("Error Class=#{err.class.name}, Message=#{err.message}")
       raise miq_exception
     end
   end
@@ -114,7 +114,7 @@ module ManageIQ::Providers::Nuage::ManagerMixin
 
   def stop_event_monitor_queue_on_change
     if event_monitor_class && !new_record? && (authentications.detect(&:changed?) || endpoints.detect(&:changed?))
-      _log.info("EMS: [#{name}], Credentials or endpoints have changed, stopping Event Monitor. It will be restarted by the WorkerMonitor.")
+      $nuage_log.info("EMS: [#{name}], Credentials or endpoints have changed, stopping Event Monitor. It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
     end
   end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   end
 
   def start(&message_handler_block)
-    _log.debug("#{self.class.log_prefix} Opening amqp connection using options #{@options}")
+    $nuage_log.debug("#{self.class.log_prefix} Opening amqp connection using options #{@options}")
     @options[:message_handler_block] = message_handler_block if message_handler_block
     with_fallback_urls(@options[:urls]) do
       connection.run
@@ -49,12 +49,12 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   def with_fallback_urls(urls)
     urls.each_with_index do |url, idx|
       endpoint_str = "ActiveMQ endpoint #{idx + 1}/#{@options[:urls].count} (#{url})"
-      _log.info("#{self.class.log_prefix} Connecting to #{endpoint_str}")
+      $nuage_log.info("#{self.class.log_prefix} Connecting to #{endpoint_str}")
       begin
         @options[:url] = url
         yield
       rescue MiqException::MiqHostError, Errno::ECONNREFUSED, SocketError => err
-        _log.info("#{self.class.log_prefix} #{endpoint_str} errored: #{err}")
+        $nuage_log.info("#{self.class.log_prefix} #{endpoint_str} errored: #{err}")
         stop
         reset_connection
       end

--- a/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
@@ -21,10 +21,10 @@ module ManageIQ::Providers
     def ems_inv_to_hashes
       log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
 
-      _log.info("#{log_header}...")
+      $nuage_log.info("#{log_header}...")
       get_enterprises
       get_policy_groups
-      _log.info(@data)
+      $nuage_log.info(@data)
       @data
     end
 
@@ -119,7 +119,7 @@ module ManageIQ::Providers
 
     def parse_policy_group(pg)
       uid = pg['ID']
-      _log.info(@domains[pg['parentID']][2])
+      $nuage_log.info(@domains[pg['parentID']][2])
       new_result = {
         :type          => self.class.security_group_type,
         :ems_ref       => uid,

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers
         @enterprise_id = data
         return
       end
-      _log.error('VSD Authentication failed')
+      $nuage_log.error('VSD Authentication failed')
     end
 
     def get_enterprises

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
@@ -36,7 +36,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest
     if @api_key == ''
       login
     end
-    _log.debug("GET for Nuage VSD url #{url}")
+    $nuage_log.debug("GET for Nuage VSD url #{url}")
     RestClient::Request.execute(:method => :get, :url => url, :user => @user, :password => @api_key,
      :headers => @headers, :verify_ssl => false) do |response|
       return response

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
     it "preserves and logs message for unknown exceptions" do
       allow(@ems).to receive(:with_provider_connection).and_raise(StandardError, "unlikely")
 
-      expect($log).to receive(:error).with(/unlikely/)
+      expect($nuage_log).to receive(:error).with(/unlikely/)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
     end
 


### PR DESCRIPTION
With this commit we redirect all Nuage specific logs into a dedicated file (instead of general-purpose evm.log).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1534449
Related PR in core: https://github.com/ManageIQ/manageiq/pull/16455 (already merged)

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes
