### PR TITLE
Handle subnets with missing gateway/netmask

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -61,6 +61,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   end
 
   def to_cidr(address, netmask)
-    address + '/' + netmask.to_s.split(".").map { |e| e.to_i.to_s(2).rjust(8, "0") }.join.count("1").to_s
+    return unless address && netmask
+    address.to_s + '/' + netmask.to_s.split(".").map { |e| e.to_i.to_s(2).rjust(8, "0") }.join.count("1").to_s
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -50,6 +50,18 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     expect(described_class.ems_type).to eq(:nuage_network)
   end
 
+  describe ".to_cidr" do
+    let(:parser) { ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager.new }
+
+    it "normal" do
+      expect(parser.send(:to_cidr, '192.168.0.0', '255.255.255.0')).to eq('192.168.0.0/24')
+    end
+
+    it "address and netmask nil" do
+      expect(parser.send(:to_cidr, nil, nil)).to be_nil
+    end
+  end
+
   describe "refresh" do
     let(:network_group_ref1) { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
     let(:network_group_ref2) { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }


### PR DESCRIPTION
We crash hard in case gateway address returned from Nuage API is `nil`. Well, not anymore.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1551015

@miq-bot add_label bug,gaprindashvili/yes
@miq-bot assign @juliancheal 