### PR TITLE
Don't run EventCatcher when user opts-in for "None"

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
@@ -8,4 +8,14 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher < ::MiqEventCatch
   def self.settings_name
     :event_catcher_nuage_network
   end
+
+  def self.all_valid_ems_in_zone
+    # Only run event catcher for those Nuage providers that have credentials for it.
+    # NOTE: ATM it's safest to check if hostname is non-empty string because
+    # frontend seems to be inserting empty Authentication and Endpoint even
+    # if user opts-in for "None" in AMQP tab.
+    super.select do |ems|
+      ems.endpoints.any? { |e| e.role == 'amqp' && e.hostname.present? }
+    end
+  end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -27,6 +27,7 @@ FactoryGirl.define do
     after :create do |x|
       x.authentications << FactoryGirl.create(:authentication)
       x.authentications << FactoryGirl.create(:authentication, :authtype => "amqp")
+      x.endpoints       << FactoryGirl.create(:endpoint, :role => "amqp")
     end
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher_spec.rb
@@ -6,4 +6,39 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher do
   it 'settings_name' do
     expect(described_class.settings_name).to eq(:event_catcher_nuage_network)
   end
+
+  describe '#all_valid_ems_in_zone' do
+    let(:ems_without_amqp) { FactoryGirl.create(:ems_nuage_network) }
+    let(:ems_with_amqp)    { FactoryGirl.create(:ems_nuage_network_with_authentication) }
+    let(:ems_with_empty_amqp) do
+      ems = FactoryGirl.create(:ems_nuage_network_with_authentication)
+      ems.endpoints.detect { |h| h.role == 'amqp' }.update(:hostname => '')
+      ems
+    end
+
+    it 'no ems at all' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems without AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_without_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems with empty AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_empty_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems with AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([ems_with_amqp])
+    end
+
+    it 'mixture of all' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_amqp, ems_without_amqp, ems_with_empty_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([ems_with_amqp])
+    end
+  end
 end


### PR DESCRIPTION
Nuage GUI offers option "None" for eventing (as opposed to "AMQP"). Turns out that EventCatcher restarts itself like crazy in case "None" is chosen because it tries to connect to AMQP anyway even if it lacky both endpoint information and credentials.

With this commit we make sure that EventCatcher is only run for those Nuage EMSes that have option "AMQP" actually chosen.

![capture](https://user-images.githubusercontent.com/8102426/36906289-cf26cba6-1e35-11e8-8716-0fe477da3120.PNG)

NOTE: the very same approach was taken for VMware vCloud provider here: https://github.com/ManageIQ/manageiq-providers-vmware/pull/199, but @agrare hasn't approved it yet. I've tested it locally and everything works as expected, so I'm looking forward to be hearing if there is a more elegant way of achieveing this, or is it OK?

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1527209

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @agrare 