### PR TITLE
Harden refresh parser

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
 
   def cloud_subnets
     collector.cloud_subnets.each do |subnet|
-      extra = map_extra_attributes(subnet['parentID'])
+      extra = map_extra_attributes(subnet['parentID']) || {}
       persister.cloud_subnets.find_or_build(subnet['ID']).assign_attributes(
         :name             => subnet['name'],
         :cidr             => to_cidr(subnet['address'], subnet['netmask']),
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   def security_groups
     collector.security_groups.each do |sg|
       domain_id = sg['parentID']
-      domain = collector.domain(domain_id)
+      domain = collector.domain(domain_id) || {}
 
       persister.security_groups.find_or_build(sg['ID']).assign_attributes(
         :name          => sg['name'],
@@ -45,10 +45,13 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
 
   def map_extra_attributes(zone_id)
     zone = collector.zone(zone_id)
+    return unless zone
     domain_id = zone['parentID']
     domain = collector.domain(domain_id)
+    return unless domain
     network_group_id = domain['parentID']
     network_group = collector.network_group(network_group_id)
+    return unless network_group
 
     {
       "enterprise_name" => network_group['name'],

--- a/spec/models/manageiq/providers/nuage/network_manager/inventory_parser_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/inventory_parser_spec.rb
@@ -1,0 +1,92 @@
+describe ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager do
+  describe '.to_cidr' do
+    it 'normal' do
+      expect(subject.send(:to_cidr, '192.168.0.0', '255.255.255.0')).to eq('192.168.0.0/24')
+    end
+
+    it 'address and netmask nil' do
+      expect(subject.send(:to_cidr, nil, nil)).to be_nil
+    end
+  end
+
+  describe '.map_extra_attributes' do
+    before(:each) do
+      allow(subject).to receive(:collector).and_return(collector)
+    end
+
+    let(:collector)     { double('collector', :zone => zone, :domain => domain, :network_group => network_group) }
+    let(:zone)          { {} }
+    let(:domain)        { {} }
+    let(:network_group) { {} }
+
+    context 'when zone not found' do
+      let(:zone) { nil }
+      it 'invoke' do
+        expect(subject.send(:map_extra_attributes, 'the-zone')).to eq(nil)
+      end
+    end
+
+    context 'when domain not found' do
+      let(:domain) { nil }
+      it 'invoke' do
+        expect(subject.send(:map_extra_attributes, 'the-zone')).to eq(nil)
+      end
+    end
+
+    context 'when network group not found' do
+      let(:network_group) { nil }
+      it 'invoke' do
+        expect(subject.send(:map_extra_attributes, 'the-zone')).to eq(nil)
+      end
+    end
+
+    context 'regular case' do
+      let(:zone)          { { 'name' => 'Zone Name', 'parentID' => 'domain-id' } }
+      let(:domain)        { { 'name' => 'Domain Name', 'parentID' => 'network-group-id' } }
+      let(:network_group) { { 'name' => 'Network Group Name' } }
+      it 'invoke' do
+        expect(subject.send(:map_extra_attributes, 'the-zone')).to eq(
+          'enterprise_name' => 'Network Group Name',
+          'enterprise_id'   => 'network-group-id',
+          'domain_name'     => 'Domain Name',
+          'domain_id'       => 'domain-id',
+          'zone_name'       => 'Zone Name',
+          'zone_id'         => 'the-zone'
+        )
+      end
+    end
+  end
+
+  describe '.cloud_subnets' do
+    before do
+      allow(subject).to receive_message_chain(:collector, :cloud_subnets).and_return([subnet])
+      allow(subject).to receive(:map_extra_attributes).and_return(nil)
+      allow(subject).to receive(:persister).and_return(persister)
+    end
+
+    let(:persister) { double('persister') }
+    let(:subnet)    { { 'name' => 'Subnet Name', 'IPType' => 'ip-type' } }
+
+    it 'map_extra_attributes returns nothing' do
+      expect(persister).to receive_message_chain(:cloud_subnets, :find_or_build, :assign_attributes).with(hash_including(:extra_attributes => {}))
+      expect(persister).to receive_message_chain(:network_groups, :lazy_find).with(nil)
+      subject.send(:cloud_subnets)
+    end
+  end
+
+  describe '.security_groups' do
+    before do
+      allow(subject).to receive(:collector).and_return(collector)
+      allow(subject).to receive(:persister).and_return(persister)
+    end
+
+    let(:persister) { double('persister') }
+    let(:collector) { double('collector', :domain => nil, :security_groups => [{}]) }
+
+    it 'domain not found' do
+      expect(persister).to receive_message_chain(:security_groups, :find_or_build, :assign_attributes).with(hash_including(:network_group => nil))
+      expect(persister).to receive_message_chain(:network_groups, :lazy_find).with(nil)
+      subject.send(:security_groups)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -50,18 +50,6 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     expect(described_class.ems_type).to eq(:nuage_network)
   end
 
-  describe ".to_cidr" do
-    let(:parser) { ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager.new }
-
-    it "normal" do
-      expect(parser.send(:to_cidr, '192.168.0.0', '255.255.255.0')).to eq('192.168.0.0/24')
-    end
-
-    it "address and netmask nil" do
-      expect(parser.send(:to_cidr, nil, nil)).to be_nil
-    end
-  end
-
   describe "refresh" do
     let(:network_group_ref1) { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
     let(:network_group_ref2) { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }


### PR DESCRIPTION
Turns out that Nuage allows strange things to exist in its database when modifying it through their REST API (GUI asserts certain validation, but not REST API). With this commit we take some precautions, because we don't want our refresher to be crashing in such cases.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1551015

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @juliancheal 

