### PR TITLE
[WIP] Prevent AMQP connection from being closed periodically

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/qpid_container.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/qpid_container.rb
@@ -1,0 +1,80 @@
+# NOTE: here we patch Qpid::Proton::Container object to tackle two blocking bugs that we observed:
+# a) sockets are not being closed properly upon connection close which resulty in file descriptor leakage
+# b) AMQP heartbeat is not being sent which results in periodically closing connection every minute or two
+# See https://issues.apache.org/jira/browse/PROTON-1791
+# TODO: remove this entire class once the issues are fixed (should be in qpid_proton 0.22.0)
+
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::QpidContainer < Qpid::Proton::Container
+  # Override to capture connection drivers.
+  def connection_driver(io, opts = nil, server = false)
+    driver = super(io, opts, server)
+
+    # Capture connection drivers so that we can manually poke them later.
+    @drivers ||= []
+    @drivers << driver
+
+    driver
+  end
+
+  # Override to also start poking thread upon container start.
+  def run
+    $nuage_log.debug("#{self.class.log_prefix} Run container called")
+    poke_drivers_thread_start
+    super
+  end
+
+  # Override to also stop poking thread upon container stop.
+  def stop(error = nil)
+    $nuage_log.debug("#{self.class.log_prefix} Stop container called")
+    super(error)
+    poke_drivers_thread_stop
+    close_sockets
+  end
+
+  def self.log_prefix
+    "MIQ(#{name})"
+  end
+
+  private
+
+  # Manually close sockets or else they remain in CLOSE_WAIT statue forever consuming file descriptors.
+  def close_sockets
+    $nuage_log.debug("#{self.class.log_prefix} Closing sockets")
+    @drivers.each { |d| d.to_io.close } if @drivers
+    @drivers = nil
+  end
+
+  # Invoke 'process' function on all current drivers to prevent ActiveMQ from disconnecting us with
+  # 'amqp:resource-limit-exceeded: local-idle-timeout expired' error.
+  def poke_drivers
+    active_drivers = (@drivers || []).reject(&:finished?)
+    $nuage_log.debug("#{self.class.log_prefix} Poking #{active_drivers.size} drivers")
+    active_drivers.each(&:process) if @drivers
+  end
+
+  # Run poke_drivers function every 5 seconds (in auxilary thread).
+  def poke_drivers_thread_start
+    unless @poking
+      @poking = true
+      $nuage_log.debug("#{self.class.log_prefix} Start poking drivers")
+      Thread.new do
+        begin
+          while @poking
+            sleep(5)
+            poke_drivers
+          end
+        rescue StandardError => e
+          $nuage_log.debug("#{self.class.log_prefix} Error in poking drivers thread: #{e}")
+        end
+        $nuage_log.debug("#{self.class.log_prefix} Stop poking drivers")
+        @poking = false
+      end
+    end
+  end
+
+  # Request auxilary thread to terminate.
+  def poke_drivers_thread_stop
+    $nuage_log.debug("#{self.class.log_prefix} Stop poking drivers requested")
+    @poking = false
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   def connection
     unless @connection
       @handler = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(@options.clone)
-      @connection = Qpid::Proton::Container.new(@handler)
+      @connection = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::QpidContainer.new(@handler)
     end
     @connection
   end


### PR DESCRIPTION
With this commit we address two serious bugs that exist in qpid_proton gem:

1) Abruptly closed connections are leaking file descriptors
2) Connection gets abruptly closed every 2 minutes due to missing heartbeats

---

When AMQP connection is closed abruptly it results in TCP socket remaining open in CLOSE_WAIT state, which means file descriptor is not released:

```
$ ps -ef | grep MIQ
miha     108492     4234  3 12:02 pts/6    00:01:40 MIQ Server
miha   **108533** 108492  0 12:02 pts/6    00:00:07 MIQ: Nuage::NetworkManager::EventCatcher id: 105, queue: ems_3
miha     108545   108492  0 12:02 pts/6    00:00:02 MIQ: MiqEventHandler id: 106, queue: ems
miha     108554   108492  0 12:02 pts/6    00:00:04 MIQ: MiqGenericWorker id: 107, queue: generic

$ lsof -ap 108533 | grep CLOSE_WAIT
ruby    108533 miha  116u  IPv4   562438  0t0  TCP 172.16.117.189:53626->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  197u  IPv4   561644  0t0  TCP 172.16.117.189:53630->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  311u  IPv4   560657  0t0  TCP 172.16.117.189:53634->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  549u  IPv4   565342  0t0  TCP 172.16.117.189:53642->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  576u  IPv4   565122  0t0  TCP 172.16.117.189:53650->147.75.102.132:amqp (CLOSE_WAIT)
... (keeps growing)
```

After period of time (9 hours in our case) there are enough file descriptors open for operating system to yield:

```
Too many open files - socket(2) for "172.16.117.189" port 5672
```

This is a bug in qpid_proton gem as reported here: https://issues.apache.org/jira/browse/PROTON-1791 Until it gets resolved, we're introducing a workaround for it with this commit. Basically we capture socket references and manually close them upon closing AMQP connection.

With this commit we also fix a problem in qpid_proton gem that is not sending heartbeat to the  ActiveMQ. Then ActiveMQ thinks we're dead and closes connection abruptly. Solution for this problem is as simple as poking AMQP connection every 5 seconds so that ActiveMQ know we're still alive.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554771

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc 