### PR TITLE
Also connect to CNAAlarms AMQP topic

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,4 +22,5 @@
       :event_catcher_nuage_network:
         :topics:
           - topic/CNAMessages
+          - topic/CNAAlarms
         :amqp_connect_timeout: 5.seconds


### PR DESCRIPTION
With this commit we connect Nuage provider also to CNAAlarms topic and not only to CNAMessages topic, as requested by Nuage.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554230

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc 