### PR TITLE
[WIP] Silently reconnect qpid in case of heartbeat timeout

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
       options = @ems.event_monitor_options
       options[:topics] = worker_settings[:topics]
       options[:amqp_connect_timeout] = worker_settings[:amqp_connect_timeout]
+      options[:idle_timeout] = worker_settings[:amqp_idle_timeout]
       @event_monitor_handle = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream.new(options)
     end
     @event_monitor_handle

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,4 @@
         :topics:
           - topic/CNAMessages
         :amqp_connect_timeout: 5.seconds
+        :amqp_idle_timeout: 60.seconds


### PR DESCRIPTION
We observed that Nuage server often "forgets" to send AMQP heartbeat for some reason which results in Nuage provider's event catcher reporting the error in evm.log and reconnecting to the next fallback url.

With this commit we capture such type of exception and reconnect silently to the same fallback url to prevent event catcher from looping fallback urls for this error and also to keep evm.log clear.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554771

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc 
