### PR TITLE
Manually close AMQP sockets upon stopping event catcher

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler
   end
 
   def on_container_start(container)
+    $nuage_log.debug("#{self.class.log_prefix} Starting AMQP")
     Timeout.timeout(@timeout) { @conn = container.connect(@url, @options) }
     unless @test_connection
       @topics.each { |topic| @conn.open_receiver("topic://#{topic}") }
@@ -26,23 +27,37 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler
     connection.container.stop if @test_connection
   end
 
-  def on_connection_error(_connection)
-    raise MiqException::MiqInvalidCredentialsError, "Connection failed due to bad username or password"
+  def on_connection_error(connection)
+    msg = "#{self.class.log_prefix} AMQP on_connection_error: #{connection.condition}"
+    $nuage_log.debug(msg)
+    raise MiqException::MiqHostError, msg
   end
 
-  def on_transport_error(_transport)
-    raise MiqException::MiqHostError, "Transport error"
+  def on_transport_error(transport)
+    msg = "#{self.class.log_prefix} AMQP on_transport_error: #{transport.connection.condition}"
+    $nuage_log.debug(msg)
+    raise MiqException::MiqHostError, msg
   end
 
   def on_message(_delivery, message)
     @message_handler_block&.call(JSON.parse(message.body))
   end
 
-  def on_transport_close(_transport)
-    raise MiqException::MiqHostError, "Transport closed unexpectedly"
+  def on_transport_close(transport)
+    msg = "#{self.class.log_prefix} AMQP on_transport_close: #{transport.connection.condition}"
+    $nuage_log.debug(msg)
+    raise MiqException::MiqHostError, msg
   end
 
   def stop
-    @conn&.close
+    unless @conn.nil? || @conn.container.stopped
+      $nuage_log.debug("#{self.class.log_prefix} Stopping AMQP")
+      @conn.container.stop
+    end
+    @conn = nil
+  end
+
+  def self.log_prefix
+    "MIQ(#{name})"
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/qpid_container.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/qpid_container.rb
@@ -1,0 +1,37 @@
+# NOTE: here we patch Qpid::Proton::Container object to tackle a blocking bug that we observed where
+# sockets are not being closed properly upon connection close which results in file descriptor leakage,
+# see https://issues.apache.org/jira/browse/PROTON-1791
+# TODO: remove this entire class once the issues is fixed (hopefully with qpid_proton 0.22.0)
+
+class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::QpidContainer < Qpid::Proton::Container
+  # Override to capture connection drivers.
+  def connection_driver(io, opts = nil, server = false)
+    driver = super(io, opts, server)
+
+    # Capture connection drivers so that we can manually close them later.
+    @drivers ||= []
+    @drivers << driver
+
+    driver
+  end
+
+  # Override to manually close sockets upon container stop.
+  def stop(error = nil)
+    $nuage_log.debug("#{self.class.log_prefix} Stop container called")
+    super(error)
+    close_sockets
+  end
+
+  def self.log_prefix
+    "MIQ(#{name})"
+  end
+
+  private
+
+  # Manually close sockets or else they remain in CLOSE_WAIT statue forever consuming file descriptors.
+  def close_sockets
+    $nuage_log.debug("#{self.class.log_prefix} Closing sockets")
+    @drivers.each { |d| d.to_io.close } if @drivers
+    @drivers = nil
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/stream.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream
   def connection
     unless @connection
       @handler = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(@options.clone)
-      @connection = Qpid::Proton::Container.new(@handler)
+      @connection = ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::QpidContainer.new(@handler)
     end
     @connection
   end


### PR DESCRIPTION
With this commit we address a bugs that exist in qpid_proton gem that abruptly closed connections are leaking file descriptors. When AMQP connection is closed abruptly it results in TCP socket remaining open in CLOSE_WAIT state, which means file descriptor is not released:

```
$ ps -ef | grep MIQ
miha     108492     4234  3 12:02 pts/6    00:01:40 MIQ Server
miha   **108533** 108492  0 12:02 pts/6    00:00:07 MIQ: Nuage::NetworkManager::EventCatcher id: 105, queue: ems_3
miha     108545   108492  0 12:02 pts/6    00:00:02 MIQ: MiqEventHandler id: 106, queue: ems
miha     108554   108492  0 12:02 pts/6    00:00:04 MIQ: MiqGenericWorker id: 107, queue: generic

$ lsof -ap 108533 | grep CLOSE_WAIT
ruby    108533 miha  116u  IPv4   562438  0t0  TCP 172.16.117.189:53626->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  197u  IPv4   561644  0t0  TCP 172.16.117.189:53630->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  311u  IPv4   560657  0t0  TCP 172.16.117.189:53634->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  549u  IPv4   565342  0t0  TCP 172.16.117.189:53642->147.75.102.132:amqp (CLOSE_WAIT)
ruby    108533 miha  576u  IPv4   565122  0t0  TCP 172.16.117.189:53650->147.75.102.132:amqp (CLOSE_WAIT)
... (keeps growing)
```

After period of time (9 hours in our case) there are enough file descriptors open for
operating system to yield:

```
Too many open files - socket(2) for "172.16.117.189" port 5672
```

This is a bug in qpid_proton gem as reported here: https://issues.apache.org/jira/browse/PROTON-1791 Until it gets resolved, we're introducing a workaround for it with this commit. Basically we capture socket references and manually close them upon closing AMQP connection.

We also add some more debug logging to the messaging handler with this commit to be able to debug why connection is even being closed abruptly.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554771

@miq-bot assign @juliancheal
@miq-bot add_label enhancement,gaprindashvili/yes