### PR TITLE
Move qpid_proton dependency from core repo to nuage repo

### DIFF
--- a/manageiq-providers-nuage.gemspec
+++ b/manageiq-providers-nuage.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "excon",       "~>0.40"
+  s.add_runtime_dependency "qpid_proton", "~>0.19.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
With this commit we introduce qpid_proton dependency directly here on Nuage provider. It was originally put to the core repo because it was only installable from github repository. This is no longer the case as gem is available in RubyGems repository:

https://rubygems.org/gems/qpid_proton

We want to be able to shift gem version when Nuage provider integration proceeds without affecting the core repo therefore it's better for it to reside here.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554771
(BZ above is the reason why we want to shift qpid proton version to 0.22.0, but in the intermediate step the core version must match with plugin's version or else we get `Bundler could not find compatible versions`)

@miq-bot assign @juliancheal
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc 
