### PR TITLE
Prefix Nuage events with "nuage_"

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_parser.rb
@@ -1,11 +1,22 @@
 module ManageIQ::Providers::Nuage::NetworkManager::EventParser
   def self.event_to_hash(event, ems_id)
-    event_type = "#{event['entityType']}_#{event['type'].downcase}"
+    entity = event.dig('entities', 0) || {}
+
+    case event['entityType']
+    when 'alarm'
+      type       = entity['alarmedObjectType'] || entity['targetObject']
+      event_type = "nuage_alarm_#{type}_#{event['type']}_#{entity['errorCondition']}"
+      message    = "#{entity['severity']}: #{entity['reason']}"
+    else
+      event_type = "nuage_#{event['entityType']}_#{event['type']}"
+      message    = "#{entity['name']} (#{entity['ID']})"
+    end
+
     {
       :source     => "NUAGE",
-      :event_type => event_type,
+      :event_type => event_type.downcase,
       :timestamp  => DateTime.strptime((event["eventReceivedTime"] / 1000).to_s, '%s').to_s,
-      :message    => event_type,
+      :message    => message,
       :vm_ems_ref => nil,
       :full_data  => event.to_hash,
       :ems_id     => ems_id,

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/alarm_4713.json
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/alarm_4713.json
@@ -1,0 +1,38 @@
+{
+  "userName": null,
+  "enterpriseName": null,
+  "type": "DELETE",
+  "entityType": "alarm",
+  "eventReceivedTime": 1481064781892,
+  "entities": [
+    {
+      "children": null,
+      "parentType": "nsgateway",
+      "entityScope": "ENTERPRISE",
+      "lastUpdatedBy": "43f8868f-4bc1-472c-9d19-→533dcfcb1ee0",
+      "lastUpdatedDate": 1481064781000,
+      "creationDate": 1481064781000,
+      "name": "nsg[NSG-Ottawa:213.50.60.102] vsc[vsc1:100.100.100.21]",
+      "reason": "Gateway with system-id [213.50.60.102] is disconnected from controller [vsc1:100.100.100.21]",
+      "description": "Gateway with system-id [NSG-Ottawa] is disconnected from controller [213.50.60.102:vsc1]",
+      "alarmTimeStamp": 1481064781785,
+      "acknowledged": false,
+      "alarmId": "NSG-Ottawa:213.50.60.102:vsc1:100.100.100.21:DISCONNECTED",
+      "numberOfOccurances": 1,
+      "alarmedObjectType": "nsgateway",
+      "alarmedObjectId": "05117fac-eac2-4ed7-b421-e70fcb42daee",
+      "severity": "MAJOR",
+      "errorCondition": 4713,
+      "incrementNumberOfOccurances": false,
+      "enterpriseId": "40d29496-c5ef-41c6-aa6b-ef1cd8655457",
+      "owner": "43f8868f-4bc1-472c-9d19-533dcfcb1ee0",
+      "ID": "cfea6f5c-7dfb-4b0d-bf23-67e14bcfe067",
+      "parentID": "05117fac-eac2-4ed7-b421-e70fcb42daee",
+      "externalID": null
+    }
+  ],
+  "diffMap": null,
+  "ignoreDiffInMediationEvents": false,
+  "updateMechanism": "DEFAULT",
+  "writeToDb": true
+}

--- a/spec/models/manageiq/providers/nuage/network_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_parser_spec.rb
@@ -11,7 +11,8 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventParser do
         :name     => 'with requestID',
         :fixture  => '/event_catcher/subnet_create.json',
         :expected => {
-          :event_type => 'subnet_create',
+          :event_type => 'nuage_subnet_create',
+          :message    => 'Audit-Subnet (4e08bf9c-b679-4c82-a6f7-b298a3901d25)',
           :ems_ref    => '56e69f6e-a1fd-457f-b4c5-844cfd790153'
         }
       },
@@ -19,7 +20,8 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventParser do
         :name     => 'with null requestID',
         :fixture  => '/event_catcher/alarm_delete.json',
         :expected => {
-          :event_type => 'alarm_delete',
+          :event_type => 'nuage_alarm_nsgateway_delete_4707',
+          :message    => 'MAJOR: Gateway with system-id [201.26.92.41] is disconnected',
           :ems_ref    => 'random-11111111-2222-3333-4444-555555555555'
         }
       },
@@ -27,7 +29,17 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventParser do
         :name     => 'with empty requestID',
         :fixture  => '/event_catcher/alarm_create.json',
         :expected => {
-          :event_type => 'alarm_create',
+          :event_type => 'nuage_alarm_nsgateway_create_4707',
+          :message    => 'MAJOR: Gateway with system-id [213.50.60.102] is disconnected',
+          :ems_ref    => 'random-11111111-2222-3333-4444-555555555555'
+        }
+      },
+      {
+        :name     => 'alarm 4713',
+        :fixture  => '/event_catcher/alarm_4713.json',
+        :expected => {
+          :event_type => 'nuage_alarm_nsgateway_delete_4713',
+          :message    => 'MAJOR: Gateway with system-id [213.50.60.102] is disconnected from controller [vsc1:100.100.100.21]',
           :ems_ref    => 'random-11111111-2222-3333-4444-555555555555'
         }
       }
@@ -37,7 +49,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventParser do
         example[:expected][:ems_id] = ems.id
         example[:expected][:vm_ems_ref] = nil
         example[:expected][:source] = 'NUAGE'
-        example[:expected][:message] = example[:expected][:event_type] if example[:expected][:event_type]
+        example[:expected][:message] = example[:expected][:message]
         example[:expected][:full_data] = message.to_hash
         expect(described_class.event_to_hash(message, ems.id)).to include(example[:expected])
       end


### PR DESCRIPTION
With this commit we prefix Nuage events with distinct prefix to uniquely differentiate event type between providers, mostly for the sake of event timelines. Additionally, we enhance alarm event type to contain more details about the actual error.

Event types before:

```
subnet_create
alarm_create
```

Event types after:

```
nuage_subnet_create
nuage_alarm_nsgateway_create_4707
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1571838

@miq-bot assign @juliancheal 
@miq-bot add_label enhancement,gaprindashvili/yes