### PR TITLE
Cleanup config/settings.yaml after changes in UI

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,8 +14,6 @@
   :nuage_network:
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
-:product:
-  :nuage: true
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
With this commit we cleanup settings.yaml since UI no longer needs `::Settings.product.nuage` setting but rather relies on config/permissions.yaml entries.

Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/3979

/cc @djberg96 