### PR TITLE
Bug 1518304: Don't show events tab for openstack network provider edit

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   require_nested :NetworkGroup
 
   supports :ems_network_new
+  supports :configure_events
 
   include Vmdb::Logging
   include ManageIQ::Providers::Nuage::ManagerMixin


### PR DESCRIPTION
Add supports entry for events configuration for nuage network provider.

After https://github.com/ManageIQ/manageiq-ui-classic/pull/3832 this is needed to show the event tab for the cloud and infra provider edit page.