### PR TITLE
Inventory L2 Domain entity (Nuage) as CloudSubnet model (MIQ)

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/collector.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector.rb
@@ -9,11 +9,12 @@ class ManageIQ::Providers::Nuage::Inventory::Collector < ManagerRefresh::Invento
   end
 
   def initialize_inventory_sources
-    @cloud_tenants   = {}
-    @cloud_subnets   = []
-    @security_groups = []
-    @zones           = {}
-    @network_routers = {}
+    @cloud_tenants    = {}
+    @cloud_subnets    = []
+    @l2_cloud_subnets = []
+    @security_groups  = []
+    @zones            = {}
+    @network_routers  = {}
   end
 
   def vsd_client

--- a/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/network_manager.rb
@@ -12,6 +12,11 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::NetworkManager < ManageI
     @cloud_subnets = vsd_client.get_subnets
   end
 
+  def l2_cloud_subnets
+    return @l2_cloud_subnets if @l2_cloud_subnets.any?
+    @l2_cloud_subnets = vsd_client.get_l2_domains
+  end
+
   def security_groups
     return @security_groups if @security_groups.any?
     @security_groups = vsd_client.get_policy_groups

--- a/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection < Manag
     @cloud_subnets_map.values.compact
   end
 
+  def l2_cloud_subnets
+    [] # TODO(miha-plesko): targeted refresh for l2_cloud_subnets
+  end
+
   def security_groups
     return [] if references(:security_groups).blank?
     references(:security_groups).collect { |ems_ref| security_group(ems_ref) }

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -8,6 +8,8 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   require_nested :CloudTenant
   require_nested :NetworkRouter
   require_nested :CloudSubnet
+  require_nested :CloudSubnetL3
+  require_nested :CloudSubnetL2
   require_nested :SecurityGroup
 
   supports :ems_network_new
@@ -41,11 +43,27 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
     ManageIQ::Providers::Nuage::NetworkManager::EventCatcher
   end
 
+  def self.l2_cloud_subnet_type
+    'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2'
+  end
+
+  def self.l3_cloud_subnet_type
+    'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3'
+  end
+
   def name
     self[:name]
   end
 
   def cloud_tenants
     ::CloudTenant.where(:ems_id => id)
+  end
+
+  def l3_cloud_subnets
+    cloud_subnets.where(:type => self.class.l3_cloud_subnet_type)
+  end
+
+  def l2_cloud_subnets
+    cloud_subnets.where(:type => self.class.l2_cloud_subnet_type)
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l2.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l2.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l3.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l3.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb
@@ -1,2 +1,9 @@
 class ManageIQ::Providers::Nuage::NetworkManager::CloudTenant < ::CloudTenant
+  def l3_cloud_subnets
+    cloud_subnets.where(:type => self.class.parent.l3_cloud_subnet_type)
+  end
+
+  def l2_cloud_subnets
+    cloud_subnets.where(:type => self.class.parent.l2_cloud_subnet_type)
+  end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -78,6 +78,10 @@ module ManageIQ::Providers
       get_list("domains/#{domain_id}/policygroups")
     end
 
+    def get_l2_domains
+      get_list('l2domains')
+    end
+
     private
 
     # TODO(miha-plesko): Is this filter really supposed to be used here in client? Looks like debugging leftover,

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -233,7 +233,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :dns_nameservers                => nil,
       :ipv6_router_advertisement_mode => nil,
       :ipv6_address_mode              => nil,
-      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet",
+      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3",
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,9 @@ require 'qpid_proton'
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Nuage::Engine.root, 'spec/vcr_cassettes')
+  config.default_cassette_options = {
+    :decode_compressed_response => true
+  }
 end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
@@ -566,4 +566,62 @@ http_interactions:
         DFKRxYmUKUs/nj4B8q6H7Q8CAAA=
     http_version: 
   recorded_at: Wed, 23 Aug 2017 15:27:31 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/l2domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjowMGYyNjA5Yy02OWJkLTQ3MTItOGU5ZC1jM2JhODcwM2NmMDg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Wed, 30-May-2018 13:50:10
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Nuage-Orderby:
+      - name ASC
+      X-Nuage-Count:
+      - '4'
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 31 May 2018 13:50:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1501769462000,"description":null,"name":"BridgeNet","gateway":null,"dynamicIpv6Address":true,"address":null,"netmask":null,"maintenanceMode":"DISABLED","routeDistinguisher":"65534:48730","routeTarget":"65534:58582","vnId":10076398,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"7dcd3108-ce83-45a5-88db-4ad5f32e2eb4","parentID":"713d0ba0-dea8-44b4-8ac7-6cab9dc321a7","externalID":null,"DHCPManaged":false,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":null,"stretched":false,"templateID":"688a33dc-b5c3-47f6-b72b-687be70eb953","associatedSharedNetworkResourceID":null,"serviceID":834027956,"gatewayMACAddress":null,"uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"},{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1501769486000,"description":null,"name":"FlatNet","gateway":"10.99.99.1","dynamicIpv6Address":true,"address":"10.99.99.0","netmask":"255.255.255.0","maintenanceMode":"DISABLED","routeDistinguisher":"65534:29749","routeTarget":"65534:65409","vnId":4479255,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"3b733a41-774d-4aaa-8e64-588d5533a5c0","parentID":"713d0ba0-dea8-44b4-8ac7-6cab9dc321a7","externalID":null,"DHCPManaged":true,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":"IPV4","stretched":false,"templateID":"8e45727f-30d6-4d96-82f1-8c1ab60080d9","associatedSharedNetworkResourceID":null,"serviceID":529488222,"gatewayMACAddress":"68:54:ED:00:76:39","uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"},{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1507800660000,"description":null,"name":"L2Base","gateway":"10.99.99.1","dynamicIpv6Address":true,"address":"10.99.99.0","netmask":"255.255.255.0","maintenanceMode":"DISABLED","routeDistinguisher":"65534:49843","routeTarget":"65534:45277","vnId":13806772,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"03a955bc-add4-4346-abb5-85701477fa4e","parentID":"e0819464-e7fc-4a37-b29a-e72da7b5956c","externalID":null,"DHCPManaged":true,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":"IPV4","stretched":false,"templateID":"c43eece8-22d3-4365-b1c8-0b1b8639f2e2","associatedSharedNetworkResourceID":null,"serviceID":972881280,"gatewayMACAddress":"68:54:ED:00:A4:F6","uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"},{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1507800673000,"description":null,"name":"L2Un","gateway":null,"dynamicIpv6Address":true,"address":null,"netmask":null,"maintenanceMode":"DISABLED","routeDistinguisher":"65534:61046","routeTarget":"65534:27352","vnId":1282841,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"8efc78b0-df2a-4c6f-964b-463a9d106bed","parentID":"e0819464-e7fc-4a37-b29a-e72da7b5956c","externalID":null,"DHCPManaged":false,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":null,"stretched":false,"templateID":"66b97ea1-c7c5-4d67-b606-37a0560d89f0","associatedSharedNetworkResourceID":null,"serviceID":217461762,"gatewayMACAddress":null,"uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"}]'
+    http_version: 
+  recorded_at: Thu, 31 May 2018 13:50:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we introduce a subclass of CloudSubnet model that represents a standalone subnet, called "L2 domain" on Nuage. Main difference is that such standalone domain is not connected to any NetworkRouter.

We're introducing `CloudSubnetL2` because it's important for Nuage that they are able to differentiate between the two (L3 subnet and L2 subnet). Hence we also introduce auxilary methods `l3_cloud_subnets` and `l2_cloud_subnets` on NetworkManager and CloudTenant model to be able to only get desired subnet type.

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574921