### PR TITLE
Temporarily remove many-to-many from NetworkRouter

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/network_router.rb
@@ -1,3 +1,8 @@
 class ManageIQ::Providers::Nuage::NetworkManager::NetworkRouter < ::NetworkRouter
   has_many :floating_ips, :dependent => :destroy
+
+  # TODO(miha-plesko): remove when https://github.com/ManageIQ/manageiq-schema/pull/217 is merged
+  def floating_ips
+    FloatingIp.none
+  end
 end


### PR DESCRIPTION
With this commit we remove relation which allows NetworkRouter to relate to multiple FloatingIps directly (instead via CloudNetwork). Until https://github.com/ManageIQ/manageiq-schema/pull/217 is merged we are not able to use such direct relation or else UI crashes.