### PR TITLE
[DO NOT MERGE] Initial support for AnsibleRunner-driven CRUD

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -19,9 +19,13 @@ module ManageIQ::Providers::Nuage::ManagerMixin
       end
     end
 
-    def auth_url(protocol, server, port, version)
+    def base_url(protocol, server, port)
       scheme = %w(ssl ssl-with-validation).include?(protocol) ? "https" : "http"
-      URI::Generic.build(:scheme => scheme, :host => server, :port => port, :path => "/nuage/api/#{version}").to_s
+      URI::Generic.build(:scheme => scheme, :host => server, :port => port).to_s
+    end
+
+    def auth_url(protocol, server, port, version)
+      URI(base_url(protocol, server, port)).tap { |url| url.path = "/nuage/api/#{version}" }.to_s
     end
 
     def translate_exception(err)

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -91,4 +91,53 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   def l2_cloud_subnets
     cloud_subnets.where(:type => self.class.l2_cloud_subnet_type)
   end
+
+  def ansible_env_vars
+    {}
+  end
+
+  def ansible_extra_vars(extra)
+    {
+      :nuage_auth => {
+        :api_username   => default_authentication.userid,
+        :api_password   => default_authentication.password,
+        :api_enterprise => 'csp',
+        :api_version    => api_version.sub('.', '_'),
+        :api_url        => self.class.base_url(
+          default_endpoint.security_protocol,
+          default_endpoint.hostname,
+          default_endpoint.port
+        )
+      }
+    }.merge(extra)
+  end
+
+  def ansible_root
+    ManageIQ::Providers::Nuage::Engine.root.join("content_tmp/ansible")
+  end
+
+  def playbook(name)
+    ansible_root.join(name)
+  end
+
+  def create_cloud_subnet_queue(userid, options = {})
+    task_opts = {
+      :action => "creating Cloud Subnet for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'create_cloud_subnet',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_cloud_subnet(options)
+    CloudSubnet.raw_create_cloud_subnet(self, options)
+  end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
@@ -1,2 +1,60 @@
 class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet < ::CloudSubnet
+  supports :delete
+  supports :create
+
+  def delete_cloud_subnet_queue(userid)
+    task_opts = {
+      :action => "deleting Cloud Subnet for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'raw_delete_cloud_subnet',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def raw_delete_cloud_subnet
+    $nuage_log.info("Deleting Cloud Subnet (ems_ref = #{ems_ref})")
+
+    Ansible::Runner.run(
+      ext_management_system.ansible_env_vars,
+      ext_management_system.ansible_extra_vars(:id => ems_ref),
+      ext_management_system.playbook('remove-subnet.yml')
+    )
+
+    $nuage_log.info("Done deleting Cloud Subnet (ems_ref = #{ems_ref})")
+  rescue => e
+    $nuage_log.error "Error deleting Cloud Subnet: #{e}"
+    raise MiqException::MiqCloudSubnetDeleteError
+  end
+
+  def self.raw_create_cloud_subnet(ext_management_system, options)
+    $nuage_log.info("Create Cloud Subnet (ems_ref = #{ems_ref})")
+
+    # TODO: update UI to match what Nuage needs
+
+    subnet = Ansible::Runner.run(
+      ext_management_system.ansible_env_vars,
+      ext_management_system.ansible_extra_vars(
+        :domain_id => options[:router_id],
+        :subnet_attributes => { :name => options[:name] }
+      ),
+      ext_management_system.playbook('remove-subnet.yml')
+    )
+
+    $nuage_log.info("Done creating Cloud Subnet (ems_ref = #{ems_ref})")
+
+    # TODO: can playbook return value?
+
+    {:ems_ref => subnet.id, :name => options[:name]}
+  rescue => e
+    $nuage_log.error "Error creating Cloud Subnet: #{e}"
+    raise MiqException::MiqCloudSubnetCreateError
+  end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/floating_ip.rb
@@ -1,2 +1,35 @@
 class ManageIQ::Providers::Nuage::NetworkManager::FloatingIp < ::FloatingIp
+  supports :delete
+
+  def delete_floating_ip_queue(userid)
+    task_opts = {
+      :action => "deleting Floating Ip for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'raw_delete_floating_ip',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def raw_delete_floating_ip
+    $nuage_log.info("Deleting Floating Ip (ems_ref = #{ems_ref})")
+
+    Ansible::Runner.run(
+      ext_management_system.ansible_env_vars,
+      ext_management_system.ansible_extra_vars(:id => ems_ref),
+      ext_management_system.playbook('remove-floating-ip.yml')
+    )
+
+    $nuage_log.info("Done deleting Floating Ip (ems_ref = #{ems_ref})")
+  rescue => e
+    $nuage_log.error "Error deleting Floating Ip: #{e}"
+    raise MiqException::MiqCloudSubnetDeleteError
+  end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/security_group.rb
@@ -1,2 +1,35 @@
 class ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup < ::SecurityGroup
+  supports :delete
+
+  def delete_security_group_queue(userid)
+    task_opts = {
+      :action => "deleting Security Group for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'raw_delete_security_group',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def raw_delete_security_group
+    $nuage_log.info("Deleting Security Group (ems_ref = #{ems_ref})")
+
+    Ansible::Runner.run(
+      ext_management_system.ansible_env_vars,
+      ext_management_system.ansible_extra_vars(:id => ems_ref),
+      ext_management_system.playbook('remove-policy-group.yml')
+    )
+
+    $nuage_log.info("Done deleting Security Group (ems_ref = #{ems_ref})")
+  rescue => e
+    $nuage_log.error "Error deleting Security Group: #{e}"
+    raise MiqException::MiqSecurityGroupDeleteError
+  end
 end

--- a/content_tmp/ansible/create-subnet.yml
+++ b/content_tmp/ansible/create-subnet.yml
@@ -1,0 +1,25 @@
+---
+# Playbook Inputs:
+# domain_id (string) domain to connect the new subnet to
+# subnet_attributes (hash) desired subnet attributes
+
+- name: Create Subnet
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  tasks:
+    - include_role:
+        name: create_child_entity
+      vars:
+        entity_type: Zone
+        parent_type: Domain
+        parent_id: '{{ domain_id }}'
+        attributes:
+          name: 'CloudForms Subnets'
+    - include_role:
+        name: create_child_entity
+      vars:
+        entity_type: Subnet
+        parent_type: Zone
+        parent_id: '{{ result.id }}'
+        attributes: '{{ subnet_attributes }}'

--- a/content_tmp/ansible/remove-floating-ip.yml
+++ b/content_tmp/ansible/remove-floating-ip.yml
@@ -1,0 +1,12 @@
+---
+# Playbook Inputs:
+# id (string) floating ip id
+
+- name: Remove Floating Ip
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    entity_type: FloatingIp
+  roles:
+    - remove_entity

--- a/content_tmp/ansible/remove-policy-group.yml
+++ b/content_tmp/ansible/remove-policy-group.yml
@@ -1,0 +1,12 @@
+---
+# Playbook Inputs:
+# id (string) policy group id
+
+- name: Remove Policy Group
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    entity_type: PolicyGroup
+  roles:
+    - remove_entity

--- a/content_tmp/ansible/remove-subnet.yml
+++ b/content_tmp/ansible/remove-subnet.yml
@@ -1,0 +1,12 @@
+---
+# Playbook Inputs:
+# id (string) subnet id
+
+- name: Remove Subnet
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    entity_type: Subnet
+  roles:
+    - remove_entity

--- a/content_tmp/ansible/roles/create_child_entity/tasks/main.yml
+++ b/content_tmp/ansible/roles/create_child_entity/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- debug: msg="Creating entity..."
+- local_action:
+    module: nuage_vspk
+    auth: '{{ nuage_auth }}'
+    type: '{{ entity_type }}'
+    parent_type: '{{ parent_type }}'
+    parent_id: '{{ parent_id }}'
+    state: present
+    properties: '{{ attributes }}'
+  register: result
+- debug: var=result
+- debug: msg="Done creating entity."

--- a/content_tmp/ansible/roles/remove_entity/tasks/main.yml
+++ b/content_tmp/ansible/roles/remove_entity/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- debug: msg="Removing entity..."
+- local_action:
+    module: nuage_vspk
+    auth: '{{ nuage_auth }}'
+    type: '{{ entity_type }}'
+    id: '{{ id }}'
+    state: absent
+  register: result
+- debug: var=result
+- debug: msg="Done removing entity."


### PR DESCRIPTION
With this commit we provide initial support for AnsibleRunner-driven CRUD operations. We provide following ice-breaking examples:

- DELETE (cloud subnet, floating ip, security group)
- CREATE (cloud subnet)

The DELETE functionality is fully functional with this PR, but the CREATE functionality isn't yet, because it needs UI changes.