### PR TITLE
Properly subclass CloudSubnet

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -9,8 +9,6 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   require_nested :NetworkRouter
   require_nested :CloudNetwork
   require_nested :CloudSubnet
-  require_nested :CloudSubnetL3
-  require_nested :CloudSubnetL2
   require_nested :SecurityGroup
   require_nested :FloatingIp
   require_nested :NetworkPort
@@ -48,11 +46,11 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
     end
 
     def l2_cloud_subnet_type
-      'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2'
+      'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2'
     end
 
     def l3_cloud_subnet_type
-      'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3'
+      'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3'
     end
 
     def floating_cloud_network_type

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet/l2.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet/l2.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet/l3.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet/l3.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l2.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l2.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
-end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l3.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet_l3.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3 < ::ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet
-end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -197,7 +197,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :dns_nameservers                => nil,
       :ipv6_router_advertisement_mode => nil,
       :ipv6_address_mode              => nil,
-      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3",
+      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3",
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
@@ -222,7 +222,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :dns_nameservers                => nil,
       :ipv6_router_advertisement_mode => nil,
       :ipv6_address_mode              => nil,
-      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3",
+      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3",
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
@@ -240,7 +240,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :cidr              => '10.99.99.0/24',
       :network_protocol  => 'ipv4',
       :cloud_tenant_id   => CloudTenant.find_by(:ems_ref => tenant_ref1).id,
-      :type              => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2',
+      :type              => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2',
       :network_router_id => nil
     )
 
@@ -250,7 +250,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :cidr              => nil,
       :network_protocol  => '',
       :cloud_tenant_id   => CloudTenant.find_by(:ems_ref => tenant_ref2).id,
-      :type              => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2',
+      :type              => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2',
       :network_router_id => nil
     )
   end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -233,7 +233,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :dns_nameservers                => nil,
       :ipv6_router_advertisement_mode => nil,
       :ipv6_address_mode              => nil,
-      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3",
+      :type                           => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3",
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {


### PR DESCRIPTION
With this commit we fix current strange subclassing:

```
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL2
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnetL3
```

into proper one (notice `::L2` and `::L3` at the end):

```
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3
```