### PR TITLE
Targeted refresh for L2 and L3 CloudSubnets

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
@@ -26,7 +26,9 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
     when 'enterprise'
       add_targets(target_collection, :cloud_tenants, event.full_data['entities'])
     when 'subnet'
-      add_targets(target_collection, :cloud_subnets, event.full_data['entities'])
+      add_targets(target_collection, :cloud_subnets, event.full_data['entities'], :options => { :kind => 'L3' })
+    when 'l2domain'
+      add_targets(target_collection, :cloud_subnets, event.full_data['entities'], :options => { :kind => 'L2' })
     when 'policygroup'
       add_targets(target_collection, :security_groups, event.full_data['entities'])
     when 'domain'
@@ -38,11 +40,11 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
     target_collection.targets
   end
 
-  def add_targets(target_collection, association, entities, key: 'ID')
+  def add_targets(target_collection, association, entities, key: 'ID', options: {})
     return unless entities.respond_to?(:each)
     entities.each do |obj|
       next if obj[key].to_s.empty?
-      target_collection.add_target(:association => association, :manager_ref => {:ems_ref => obj[key]})
+      target_collection.add_target(:association => association, :manager_ref => {:ems_ref => obj[key]}, :options => options)
     end
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -98,6 +98,10 @@ module ManageIQ::Providers
       get_list('l2domains')
     end
 
+    def get_l2_domain(id)
+      get_first("l2domains/#{id}")
+    end
+
     def get_floating_ips
       get_list('floatingips')
     end

--- a/spec/factories/cloud_subnet.rb
+++ b/spec/factories/cloud_subnet.rb
@@ -2,4 +2,12 @@ FactoryGirl.define do
   factory :cloud_subnet_nuage,
           :class  => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet",
           :parent => :cloud_subnet
+
+  factory :cloud_subnet_l3_nuage,
+          :class  => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3",
+          :parent => :cloud_subnet_nuage
+
+  factory :cloud_subnet_l2_nuage,
+          :class  => "ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2",
+          :parent => :cloud_subnet_nuage
 end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:50:12
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:50:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"firstName":"XLAB","lastName":"User","userName":"NUAGE_NETWORK_USERID","email":"NUAGE_NETWORK_USERID@localhost","mobileNumber":null,"password":null,"role":"CSPROOT","enterpriseName":"CSP","avatarType":null,"avatarData":null,"licenseCapabilities":["ENCRYPTION_ENABLED"],"statisticsEnabled":false,"statsTSDBServerAddress":"localhost:4242","flowCollectionEnabled":false,"vssStatsInterval":30,"aarFlowStatsInterval":30,"aarProbeStatsInterval":30,"entityScope":null,"externalId":null,"ID":"5dcc7f62-7b40-4179-bdff-26bfe89eb024","APIKey":"357c861e-69b1-4daa-b482-7583ee1307a7","APIKeyExpiry":1532162751659,"enterpriseID":"76046673-d0ea-4a67-b6af-2829952f0812","externalID":null}]'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:50:12 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/l2domains/3b733a41-774d-4aaa-8e64-588d5533a5c0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjozNTdjODYxZS02OWIxLTRkYWEtYjQ4Mi03NTgzZWUxMzA3YTc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:50:12
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:50:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1501769486000,"description":null,"name":"FlatNet","gateway":"10.99.99.1","dynamicIpv6Address":true,"address":"10.99.99.0","netmask":"255.255.255.0","maintenanceMode":"DISABLED","routeDistinguisher":"65534:29749","routeTarget":"65534:65409","vnId":4479255,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"3b733a41-774d-4aaa-8e64-588d5533a5c0","parentID":"e0819464-e7fc-4a37-b29a-e72da7b5956c","externalID":null,"DHCPManaged":true,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":"IPV4","stretched":false,"templateID":"8e45727f-30d6-4d96-82f1-8c1ab60080d9","associatedSharedNetworkResourceID":null,"serviceID":529488222,"gatewayMACAddress":"68:54:ED:00:76:39","uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"}]'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:50:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet_is_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet_is_deleted.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:56:06
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:56:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"firstName":"XLAB","lastName":"User","userName":"NUAGE_NETWORK_USERID","email":"NUAGE_NETWORK_USERID@localhost","mobileNumber":null,"password":null,"role":"CSPROOT","enterpriseName":"CSP","avatarType":null,"avatarData":null,"licenseCapabilities":["ENCRYPTION_ENABLED"],"statisticsEnabled":false,"statsTSDBServerAddress":"localhost:4242","flowCollectionEnabled":false,"vssStatsInterval":30,"aarFlowStatsInterval":30,"aarProbeStatsInterval":30,"entityScope":null,"externalId":null,"ID":"5dcc7f62-7b40-4179-bdff-26bfe89eb024","APIKey":"357c861e-69b1-4daa-b482-7583ee1307a7","APIKeyExpiry":1532162751659,"enterpriseID":"76046673-d0ea-4a67-b6af-2829952f0812","externalID":null}]'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:56:06 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/l2domains/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjozNTdjODYxZS02OWIxLTRkYWEtYjQ4Mi03NTgzZWUxMzA3YTc=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:56:06
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:56:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"Cannot find l2domain with ID unexisting-ems-ref","title":"l2domain
+        not found","errors":[{"property":"","descriptions":[{"title":"l2domain not
+        found","description":"Cannot find l2domain with ID unexisting-ems-ref"}]}]}'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:56:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet_is_updated.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/l2_cloud_subnet_is_updated.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:54:42
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:54:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"firstName":"XLAB","lastName":"User","userName":"NUAGE_NETWORK_USERID","email":"NUAGE_NETWORK_USERID@localhost","mobileNumber":null,"password":null,"role":"CSPROOT","enterpriseName":"CSP","avatarType":null,"avatarData":null,"licenseCapabilities":["ENCRYPTION_ENABLED"],"statisticsEnabled":false,"statsTSDBServerAddress":"localhost:4242","flowCollectionEnabled":false,"vssStatsInterval":30,"aarFlowStatsInterval":30,"aarProbeStatsInterval":30,"entityScope":null,"externalId":null,"ID":"5dcc7f62-7b40-4179-bdff-26bfe89eb024","APIKey":"357c861e-69b1-4daa-b482-7583ee1307a7","APIKeyExpiry":1532162751659,"enterpriseID":"76046673-d0ea-4a67-b6af-2829952f0812","externalID":null}]'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:54:42 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/l2domains/3b733a41-774d-4aaa-8e64-588d5533a5c0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.3p205
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjozNTdjODYxZS02OWIxLTRkYWEtYjQ4Mi03NTgzZWUxMzA3YTc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 19-Jul-2018 10:54:42
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 20 Jul 2018 10:54:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"children":null,"parentType":"enterprise","entityScope":null,"lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","lastUpdatedDate":1515248895000,"creationDate":1501769486000,"description":null,"name":"FlatNet","gateway":"10.99.99.1","dynamicIpv6Address":true,"address":"10.99.99.0","netmask":"255.255.255.0","maintenanceMode":"DISABLED","routeDistinguisher":"65534:29749","routeTarget":"65534:65409","vnId":4479255,"policyChangeStatus":null,"entityState":null,"encryption":"DISABLED","owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e","ID":"3b733a41-774d-4aaa-8e64-588d5533a5c0","parentID":"e0819464-e7fc-4a37-b29a-e72da7b5956c","externalID":null,"DHCPManaged":true,"useGlobalMAC":"DISABLED","IPv6Gateway":null,"IPv6Address":null,"IPType":"IPV4","stretched":false,"templateID":"8e45727f-30d6-4d96-82f1-8c1ab60080d9","associatedSharedNetworkResourceID":null,"serviceID":529488222,"gatewayMACAddress":"68:54:ED:00:76:39","uplinkPreference":"PRIMARY_SECONDARY","associatedUnderlayID":null,"multicast":"DISABLED","associatedMulticastChannelMapID":null,"DPI":"DISABLED"}]'
+    http_version: 
+  recorded_at: Fri, 20 Jul 2018 10:54:42 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we adjust targeted refresh to works for both kind of subnets - CloudSubnet::L2 and CloudSubnet::L3. When we recieve event we need to pass additional information to target in order to later know what type of subnet are we updating. We need to know this because different API calls need to be used for L2 and L3 subnets...