### PR TITLE
Relate FloatingIp to NetworkRouter

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -83,8 +83,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
       persister.floating_ips.find_or_build(ip['ID']).assign_attributes(
         :address        => ip['address'],
         :cloud_network  => persister.cloud_networks.lazy_find(ip['associatedSharedNetworkResourceID']),
-        # TODO(miha-plesko): uncomment when https://github.com/ManageIQ/manageiq-schema/pull/217 is merged
-        # :network_router => persister.network_routers.lazy_find(ip['parentID']),
+        :network_router => persister.network_routers.lazy_find(ip['parentID']),
         :cloud_tenant   => persister.network_routers.lazy_find(ip['parentID'], :key => :cloud_tenant)
       )
     end

--- a/app/models/manageiq/providers/nuage/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/network_router.rb
@@ -1,8 +1,3 @@
 class ManageIQ::Providers::Nuage::NetworkManager::NetworkRouter < ::NetworkRouter
   has_many :floating_ips, :dependent => :destroy
-
-  # TODO(miha-plesko): remove when https://github.com/ManageIQ/manageiq-schema/pull/217 is merged
-  def floating_ips
-    FloatingIp.none
-  end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -262,8 +262,9 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :cloud_tenant_id => CloudTenant.find_by(:ems_ref => tenant_ref2).id,
       :type            => 'ManageIQ::Providers::Nuage::NetworkManager::FloatingIp'
     )
-    # TODO(miha-plesko): uncomment when https://github.com/ManageIQ/manageiq-schema/pull/217 is merged
-    # expect(NetworkRouter.find_by(:ems_ref => router_ref).floating_ips).to include(ip)
+    router = NetworkRouter.find_by(:ems_ref => router_ref)
+    expect(ip.network_router).to eq(router)
+    expect(router.floating_ips).to include(ip)
   end
 
   def assert_cloud_networks


### PR DESCRIPTION
With this commit we make use of recently added foreign key on NetworkRouter that's pointing to FloatingIp to connect the two.

@Ladas here we are now, https://github.com/ManageIQ/manageiq-schema/pull/217 is merged and we're able to connect FloatingIp directly to the NetworkRouter, as discussed some time ago.