### PR TITLE
Infer related CloudSubnet in case of NetworkPort refresh

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
@@ -157,10 +157,10 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection < Manag
     end
   end
 
-  def add_simple_target!(association, ems_ref)
+  def add_simple_target!(association, ems_ref, options: {})
     return if ems_ref.blank?
 
-    target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref})
+    target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref}, :options => options)
   end
 
   def infer_related_ems_refs!
@@ -173,7 +173,14 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection < Manag
   end
 
   def infer_related_ems_refs_api!
-    # infer related entities based on Nuage API here if needed
+    references(:network_ports).each do |port|
+      case port['parentType']
+      when 'subnet'
+        add_simple_target!(:cloud_subnets, port['parentID'], :options => { :kind => 'L3' })
+      when 'l2domain'
+        add_simple_target!(:cloud_subnets, port['parentID'], :options => { :kind => 'L2' })
+      end
+    end
   end
 
   def safe_call

--- a/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
@@ -20,6 +20,7 @@ module ManageIQ::Providers::Nuage::Inventory::Persister::Definitions::NetworkCol
 
   def add_cloud_subnet_network_ports(extra_properties = {})
     add_collection(network, :cloud_subnet_network_ports, extra_properties) do |builder|
+      builder.add_properties(:manager_ref_allowed_nil => %i(cloud_subnet))
       builder.add_properties(:parent => manager, :parent_inventory_collections => %i(network_ports))
     end
   end


### PR DESCRIPTION
When refreshing NetworkPort we're also updating its many-to-many relation with CloudSubnet (to store address in the intermidiate table). And this fails with ugly integritiy error if subnet is not fetched yet.

With this commit the interity error by making sure subnet is also fetched together with port.