### PR TITLE
Check for invalid api_version string

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -8,11 +8,13 @@ module ManageIQ::Providers::Nuage::ManagerMixin
       api_port    = endpoint_opts[:api_port]
       # In case API port is represented as a string, ensure it has no whitespaces.
       api_port.strip! if api_port.kind_of?(String)
-      # v5_0 is the default API version unless it is given in the opts.
-      api_version = endpoint_opts[:api_version] ? endpoint_opts[:api_version].strip : 'v5_0'
+      api_version = endpoint_opts[:api_version].to_s.strip
+
+      # TODO(miha-plesko): Update UI to never pass in invalid version string like '? string:v2 ?'
+      raise MiqException::MiqInvalidCredentialsError, 'Invalid API Version' unless api_version_valid?(api_version)
 
       url = auth_url(protocol, hostname, api_port, api_version)
-      $nuage_log.info("Connecting to Nuage VSD with url #{url}")
+      $nuage_log.debug("Connecting to Nuage VSD with url #{url}")
 
       connection_rescue_block do
         ManageIQ::Providers::Nuage::NetworkManager::VsdClient.new(url, username, password)
@@ -49,6 +51,10 @@ module ManageIQ::Providers::Nuage::ManagerMixin
 
       $nuage_log.error("Error Class=#{err.class.name}, Message=#{err.message}")
       raise miq_exception
+    end
+
+    def api_version_valid?(value)
+      !!(value =~ /^v\d+[_.]\d+/) # e.g. 'v5_0' or 'v5.0'
     end
   end
 

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest
         @api_key = extracted_data["APIKey"]
         return true, extracted_data["enterpriseID"]
       else
-        raise MiqException::MiqInvalidCredentialsError, "Login failed due to a bad username or password."
+        raise MiqException::MiqInvalidCredentialsError, "Login failed due to a bad username, password or unsupported API version."
       end
     end
   end


### PR DESCRIPTION
When user forgets to pick API version upon Nuage provider creation she gets very strange error. Problem is that in such cases our Angular passes in literally value (with questionmarks and all):

```
'? string:v2 ?'
```

This is then used to compose URL and BOOOM. With this commit we therefore manually chech that version looks like expected e.g. `v5_0` and raise error otherwise with descriptive error message which is displayed to user upon credentials validation.

Before 👎 👎 👎 :
![image](https://user-images.githubusercontent.com/8102426/43185295-c5e632f2-8feb-11e8-9de6-e83f987ff23e.png)

After 👍 👍 👍 :
![image](https://user-images.githubusercontent.com/8102426/43185187-764231a6-8feb-11e8-818b-c1aa1add4e51.png)
