### PR TITLE
Assign Nuage event types to timeline categories

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,18 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :addition:
+          :critical:
+          - !ruby/regexp /^nuage_.+_create$/
+        :deletion:
+          :critical:
+          - !ruby/regexp /^nuage_.+_delete$/
+        :update:
+          :critical:
+          - !ruby/regexp /^nuage_.+_update$/
+        :status: # alarms
+          :critical:
+          - !ruby/regexp /^nuage_alarm_.+$/
 :http_proxy:
   :nuage:
     :host:


### PR DESCRIPTION
This will make Nuage events visible in "Monitoring -> Timelines" view.

This pull request depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/4375 and is replacing #80.

@miq-bot add_label wip

/cc @miha-plesko @gberginc 