### PR TITLE
Debug log when targeted refresh takes place

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
@@ -22,6 +22,13 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
   def parse_ems_event_targets(event)
     target_collection = ManagerRefresh::TargetCollection.new(:manager => event.ext_management_system, :event => event)
 
+    $nuage_log.debug(
+      [
+        'target:', event.full_data['entityType'], '-', event.full_data['type'], '-',
+        event.full_data['entities'][0]['name'], '-', event.full_data['entities'][0]['ID']
+      ].join(' ')
+    )
+
     case event.full_data["entityType"]
     when 'enterprise'
       add_targets(target_collection, :cloud_tenants, event.full_data['entities'])


### PR DESCRIPTION
With this commit we add a simple debug log to easily debug targeted refresh if needed. It outpust following to nuage.log:

```
[----] I, [2018-...] DEBUG -- : target: domain - CREATE - Routy - 143e678c-ef2a-4b36-9bad-a6c157ba2038
[----] I, [2018-...] DEBUG -- : target: policygroup - CREATE - PolicyTEMPLATE - 3a037fd0-41b6-4fbf-a080-06ba7d93daa0
[----] I, [2018-...] DEBUG -- : target: domain - DELETE - Routy - 143e678c-ef2a-4b36-9bad-a6c157ba2038
```