### PR TITLE
[WIP] Overcome another missing event glitch of Nuage server

### DIFF
--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -312,6 +312,15 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
                 assert_deleted(network_router)
               end
             end
+
+            it "unexisting network_router is deleted (with security_group)" do
+              cloud_tenant.security_groups = [security_group]
+              test_targeted_refresh([network_router], 'network_router_with_security_groups_is_deleted',
+                                    :repeat => 1, :options => { :operation => 'DELETE' }) do
+                assert_deleted(network_router)
+                assert_deleted(security_group)
+              end
+            end
           end
         end
       end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_router_with_security_groups_is_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_router_with_security_groups_is_deleted.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic NUAGE_NETWORK_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 16-Aug-2018 14:03:42
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 17 Aug 2018 14:03:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"firstName":"XLAB","lastName":"User","userName":"NUAGE_NETWORK_USERID","email":"NUAGE_NETWORK_USERID@localhost","mobileNumber":null,"password":null,"role":"CSPROOT","enterpriseName":"CSP","avatarType":null,"avatarData":null,"licenseCapabilities":["ENCRYPTION_ENABLED"],"statisticsEnabled":false,"statsTSDBServerAddress":"localhost:4242","flowCollectionEnabled":false,"vssStatsInterval":30,"aarFlowStatsInterval":30,"aarProbeStatsInterval":30,"entityScope":null,"externalId":null,"ID":"5dcc7f62-7b40-4179-bdff-26bfe89eb024","APIKey":"a8e460c5-09e9-4834-89bf-f3fae30f1c4f","APIKeyExpiry":1534574372606,"enterpriseID":"76046673-d0ea-4a67-b6af-2829952f0812","externalID":null}]'
+    http_version: 
+  recorded_at: Fri, 17 Aug 2018 14:03:42 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/domains/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjphOGU0NjBjNS0wOWU5LTQ4MzQtODliZi1mM2ZhZTMwZjFjNGY=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 16-Aug-2018 14:03:42
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 17 Aug 2018 14:03:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"Cannot find domain with ID unexisting-ems-ref","title":"domain
+        not found","errors":[{"property":"","descriptions":[{"title":"domain not found","description":"Cannot
+        find domain with ID unexisting-ems-ref"}]}]}'
+    http_version: 
+  recorded_at: Fri, 17 Aug 2018 14:03:42 GMT
+- request:
+    method: get
+    uri: https://NUAGE_NETWORK_HOST:8443/nuage/api/v5_0/policygroups/unexisting-ems-ref
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      X-Nuage-Organization:
+      - csp
+      Content-Type:
+      - application/json; charset=UTF-8
+      Authorization:
+      - Basic eGxhYjphOGU0NjBjNS0wOWU5LTQ4MzQtODliZi1mM2ZhZTMwZjFjNGY=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 01:00:00 CET
+      Set-Cookie:
+      - rememberMe=deleteMe; Path=/nuage; Max-Age=0; Expires=Thu, 16-Aug-2018 14:03:42
+        GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-Nuage-Organization, X-Nuage-ProxyUser, X-Nuage-OrderBy, X-Nuage-FilterType,
+        X-Nuage-Filter, X-Nuage-Page, X-Nuage-PageSize, X-Nuage-Count, X-Nuage-Custom,
+        X-Nuage-ClientType
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 17 Aug 2018 14:03:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"Cannot find policygroup with ID unexisting-ems-ref","title":"policygroup
+        not found","errors":[{"property":"","descriptions":[{"title":"policygroup
+        not found","description":"Cannot find policygroup with ID unexisting-ems-ref"}]}]}'
+    http_version: 
+  recorded_at: Fri, 17 Aug 2018 14:03:42 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we overcome a bug on Nuage side that upon deletion of NetworkRouter, corresponding SecurityGroups are also being deleted, but MIQ is not informed about it because no event is emitted.

We overcome this by inferring all related SecurityGroups when "router was deleted" event occurs. Unfortunately, MIQ does not yet modell relation "security group belongs to network router" so we have to perform check for all SecurityGroups in the CloudTenant.

Depends on: https://github.com/ManageIQ/manageiq-providers-nuage/pull/125

Only latest commit is part of this PR, the first one is from #125.