### PR TITLE
Remove CloudSubnet when corresponding subnet template is deleted

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -43,6 +43,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   def cloud_subnets
     collector.cloud_subnets.each do |subnet|
       extra = map_extra_attributes(subnet['parentID']) || {}
+      extra['template_id'] = subnet['templateID']
       persister.cloud_subnets.find_or_build(subnet['ID']).assign_attributes(
         :type             => collector.manager.class.l3_cloud_subnet_type,
         :name             => subnet['name'],

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -90,6 +90,10 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
     cloud_subnets.where(:type => self.class.l2_cloud_subnet_type)
   end
 
+  def cloud_subnets_by_extra_attr(key, value)
+    cloud_subnets.where('extra_attributes ~* ?', "#{key}: #{value}\n")
+  end
+
   def ansible_env_vars
     {}
   end

--- a/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
@@ -40,13 +40,16 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
       add_targets(target_collection, :security_groups, event.full_data['entities'])
     when 'domain'
       add_targets(target_collection, :network_routers, event.full_data['entities'],
-                  :options => { :operation => event.full_data['type'].to_s.upcase })
+                  :options => { :operation => event_operation(event) })
     when 'sharednetworkresource'
       add_targets(target_collection, :cloud_networks, event.full_data['entities'])
     when 'floatingip'
       add_targets(target_collection, :floating_ips, event.full_data['entities'])
     when 'vport'
       add_targets(target_collection, :network_ports, event.full_data['entities'])
+    when 'subnettemplate'
+      add_targets(target_collection, :cloud_subnet_templates, event.full_data['entities'],
+                  :options => { :operation => event_operation(event) })
     end
 
     target_collection.targets
@@ -58,5 +61,9 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
       next if obj[key].to_s.empty?
       target_collection.add_target(:association => association, :manager_ref => {:ems_ref => obj[key]}, :options => options)
     end
+  end
+
+  def event_operation(event)
+    event.full_data['type'].to_s.upcase
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -51,20 +51,21 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   describe "refresh" do
-    let(:tenant_ref1)        { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
-    let(:tenant_ref2)        { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }
-    let(:security_group_ref) { "02e072ef-ca95-4164-856d-3ff177b9c13c" }
-    let(:cloud_subnet_ref1)  { "d60d316a-c1ac-4412-813c-9652bdbc4e41" }
-    let(:cloud_subnet_ref2)  { "debb9f88-f252-4c30-9a17-d6ae3865e365" }
-    let(:l2_subnet_ref1)     { "3b733a41-774d-4aaa-8e64-588d5533a5c0" }
-    let(:l2_subnet_ref2)     { "8efc78b0-df2a-4c6f-964b-463a9d106bed" }
-    let(:router_ref)         { "75ad8ee8-726c-4950-94bc-6a5aab64631d" }
-    let(:floating_ip_ref)    { "3a00891b-29ba-4f60-8f35-033d84aa1083" }
-    let(:network_ref)        { "17b305a7-eec9-4492-acb9-20a1d63a8ba1" }
-    let(:cont_port_ref)      { "dd9a4d57-2e24-427b-8aef-4d2925df47b2" }
-    let(:vm_port_ref)        { "15d1369e-9553-4e83-8bb9-3a6c269f81ae" }
-    let(:bridge_port_ref)    { "43b7faad-2c76-4945-9412-66a04bde7b6a" }
-    let(:host_port_ref)      { "b19075d3-a797-4dcd-93be-de52b4247e46" }
+    let(:tenant_ref1)         { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
+    let(:tenant_ref2)         { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }
+    let(:security_group_ref)  { "02e072ef-ca95-4164-856d-3ff177b9c13c" }
+    let(:cloud_subnet_ref1)   { "d60d316a-c1ac-4412-813c-9652bdbc4e41" }
+    let(:cloud_subnet_ref2)   { "debb9f88-f252-4c30-9a17-d6ae3865e365" }
+    let(:l2_subnet_ref1)      { "3b733a41-774d-4aaa-8e64-588d5533a5c0" }
+    let(:l2_subnet_ref2)      { "8efc78b0-df2a-4c6f-964b-463a9d106bed" }
+    let(:router_ref)          { "75ad8ee8-726c-4950-94bc-6a5aab64631d" }
+    let(:floating_ip_ref)     { "3a00891b-29ba-4f60-8f35-033d84aa1083" }
+    let(:network_ref)         { "17b305a7-eec9-4492-acb9-20a1d63a8ba1" }
+    let(:cont_port_ref)       { "dd9a4d57-2e24-427b-8aef-4d2925df47b2" }
+    let(:vm_port_ref)         { "15d1369e-9553-4e83-8bb9-3a6c269f81ae" }
+    let(:bridge_port_ref)     { "43b7faad-2c76-4945-9412-66a04bde7b6a" }
+    let(:host_port_ref)       { "b19075d3-a797-4dcd-93be-de52b4247e46" }
+    let(:subnet_template_ref) { "aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc" }
 
     ALL_REFRESH_SETTINGS.each do |settings|
       context "with settings #{settings}" do
@@ -201,9 +202,10 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
-        "domain_id" => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
-        "zone_name" => "Zone 1",
-        "zone_id"   => "6256954b-9dd6-43ed-94ff-9daa683ab8b0"
+        "domain_id"   => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
+        "zone_name"   => "Zone 1",
+        "zone_id"     => "6256954b-9dd6-43ed-94ff-9daa683ab8b0",
+        "template_id" => nil
       }
     )
 
@@ -226,9 +228,10 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
-        "domain_id" => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
-        "zone_name" => "Zone 0",
-        "zone_id"   => "3b11a2d0-2082-42f1-92db-0b05264f372e"
+        "domain_id"   => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
+        "zone_name"   => "Zone 0",
+        "zone_id"     => "3b11a2d0-2082-42f1-92db-0b05264f372e",
+        "template_id" => "aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc"
       }
     )
   end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
@@ -369,32 +369,36 @@ http_interactions:
       - application/json
       Transfer-Encoding:
       - chunked
-      Content-Encoding:
-      - gzip
       Vary:
       - Accept-Encoding
       Date:
       - Wed, 23 Aug 2017 15:27:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAOVV226bQBD9lWqfvdHeWXhzYpQgNZFlu32p+rDsLjEKBgRL
-        Ulr137vg4NhReonUSq0qARJzZubMzgyHD1+A3uaFaWwJorIrihmolX9xm762
-        IAKfq9KCGfCG3PVrXY3G+GYTr5arZB17qFCte1cb5aw57z0olciQJQgqZlLI
-        ZCChMpLBUGuBAy604fY0bOEfIMIc4UCEPCQIoRnQjVUur8oTkNFgBJXxBbet
-        Z8PobH8hn7O0bqfaO28mnJ9N94io3VD4uku9z5vBYnpvy3VS34v5lM01nZ2B
-        W8/4oPrj5HgIsK1u8nqoaerUTuWls6Uqtb2uzECwSNbz87fxwvs3VefsIm9d
-        Xt52ebu1jccF55RFAmMcTi4b1dxad8AwQoR47L5MDPCeXFDCZqArjW0K1cel
-        SgvrEZDcXMWrZDNyTSiIMlW09jAvNzZvX2xbF7nbN+DITTf945FOElYP5Vjv
-        Lw4zWXhfY9M0zKSEGeEEMk0RDBUOoBHKUim4pYKDab3GCJpirIhBkCDpI0iG
-        YUg8D0oRJ4JlNCDj8n1ytilVMcTsz5Isj6Y2mR43Nlm+Z2DvcjlN8rEDtrnP
-        tR3SYEE5lUHA8WHe1/OLQ0ogZMRZFC8ihCJBo3jIuJxvXu5+XRW57i/9NOsx
-        t+QcozBEgYe61GOHfju7qwtP93QS1baVzoevYL31jTE31j1Uzd3KtlXX6CPH
-        xdXFcmX9jIehdu3prtVN9amfr5YHol1XuFz7T+xZqU9015PHxVaVpS2uVX1E
-        tkyeb1hrL4sqVYVv0zH319nfJiAC4R8ICKMvCgh5nYDgVwkI+e0CQnhA5XcE
-        hAlKD/qBkcSYsn9EQAQyFAsFNVYaMoYJlJhqGApOUpNqZhk+FRBBuP9jsBSG
-        xgjIqDUwZFnmX5USkqpUpugPCYhEofQixfnPBeR8Hs3JawQEE8JDyUL0PwjI
-        x2835wL9gwgAAA==
+      string: |
+        [
+          {
+            "children":null, "parentType":"zone", "entityScope":"ENTERPRISE", "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+            "lastUpdatedDate":1501769592000, "creationDate":1501769437000, "address":"10.10.10.0", "netmask":"255.255.255.0", "name":"Subnet 0",
+            "dynamicIpv6Address":true, "gateway":"10.10.10.1", "description":null, "maintenanceMode":"DISABLED", "routeDistinguisher":"65534:61119",
+            "routeTarget":"65534:10022", "vnId":6156324, "underlayEnabled":"INHERITED", "underlay":false, "entityState":null, "splitSubnet":false,
+            "encryption":"INHERITED", "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e", "ID":"debb9f88-f252-4c30-9a17-d6ae3865e365",
+            "parentID":"3b11a2d0-2082-42f1-92db-0b05264f372e", "externalID":null, "IPv6Address":null, "IPType":"IPV4", "IPv6Gateway":null,
+            "serviceID":1635387751, "gatewayMACAddress":"68:54:ED:00:63:E4", "PATEnabled":"INHERITED", "policyGroupID":1855109907, "public":false,
+            "templateID":"aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc", "associatedSharedNetworkResourceID":null, "DHCPRelayStatus":"DISABLED",
+            "proxyARP":false, "multicast":"INHERITED", "associatedMulticastChannelMapID":null, "DPI":"INHERITED", "useGlobalMAC":"DISABLED"},
+          {
+            "children":null, "parentType":"zone", "entityScope":"ENTERPRISE", "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+            "lastUpdatedDate":1501769601000, "creationDate":1501769443000, "address":"10.10.20.0", "netmask":"255.255.255.0", "name":"Subnet 1",
+            "dynamicIpv6Address":true, "gateway":"10.10.20.1", "description":null, "maintenanceMode":"DISABLED", "routeDistinguisher":"65534:25738",
+            "routeTarget":"65534:4633", "vnId":10811344, "underlayEnabled":"INHERITED", "underlay":false, "entityState":null, "splitSubnet":false,
+            "encryption":"INHERITED", "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e", "ID":"d60d316a-c1ac-4412-813c-9652bdbc4e41",
+            "parentID":"6256954b-9dd6-43ed-94ff-9daa683ab8b0", "externalID":null, "IPv6Address":null, "IPType":"IPV4", "IPv6Gateway":null,
+            "serviceID":1809852655, "gatewayMACAddress":"68:54:ED:00:BA:A2", "PATEnabled":"INHERITED", "policyGroupID":1122598490, "public":false,
+            "templateID":null, "associatedSharedNetworkResourceID":null, "DHCPRelayStatus":"DISABLED", "proxyARP":false, "multicast":"INHERITED",
+            "associatedMulticastChannelMapID":null, "DPI":"INHERITED", "useGlobalMAC":"DISABLED"
+          }
+        ]
     http_version: 
   recorded_at: Wed, 23 Aug 2017 15:27:30 GMT
 - request:
@@ -458,32 +462,36 @@ http_interactions:
       - application/json
       Transfer-Encoding:
       - chunked
-      Content-Encoding:
-      - gzip
       Vary:
       - Accept-Encoding
       Date:
       - Wed, 23 Aug 2017 15:27:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAOVV226bQBD9lWqfvdHeWXhzYpQgNZFlu32p+rDsLjEKBgRL
-        Ulr137vg4NhReonUSq0qARJzZubMzgyHD1+A3uaFaWwJorIrihmolX9xm762
-        IAKfq9KCGfCG3PVrXY3G+GYTr5arZB17qFCte1cb5aw57z0olciQJQgqZlLI
-        ZCChMpLBUGuBAy604fY0bOEfIMIc4UCEPCQIoRnQjVUur8oTkNFgBJXxBbet
-        Z8PobH8hn7O0bqfaO28mnJ9N94io3VD4uku9z5vBYnpvy3VS34v5lM01nZ2B
-        W8/4oPrj5HgIsK1u8nqoaerUTuWls6Uqtb2uzECwSNbz87fxwvs3VefsIm9d
-        Xt52ebu1jccF55RFAmMcTi4b1dxad8AwQoR47L5MDPCeXFDCZqArjW0K1cel
-        SgvrEZDcXMWrZDNyTSiIMlW09jAvNzZvX2xbF7nbN+DITTf945FOElYP5Vjv
-        Lw4zWXhfY9M0zKSEGeEEMk0RDBUOoBHKUim4pYKDab3GCJpirIhBkCDpI0iG
-        YUg8D0oRJ4JlNCDj8n1ytilVMcTsz5Isj6Y2mR43Nlm+Z2DvcjlN8rEDtrnP
-        tR3SYEE5lUHA8WHe1/OLQ0ogZMRZFC8ihCJBo3jIuJxvXu5+XRW57i/9NOsx
-        t+QcozBEgYe61GOHfju7qwtP93QS1baVzoevYL31jTE31j1Uzd3KtlXX6CPH
-        xdXFcmX9jIehdu3prtVN9amfr5YHol1XuFz7T+xZqU9015PHxVaVpS2uVX1E
-        tkyeb1hrL4sqVYVv0zH319nfJiAC4R8ICKMvCgh5nYDgVwkI+e0CQnhA5XcE
-        hAlKD/qBkcSYsn9EQAQyFAsFNVYaMoYJlJhqGApOUpNqZhk+FRBBuP9jsBSG
-        xgjIqDUwZFnmX5USkqpUpugPCYhEofQixfnPBeR8Hs3JawQEE8JDyUL0PwjI
-        x2835wL9gwgAAA==
+      string: |
+        [
+          {
+            "children":null, "parentType":"zone", "entityScope":"ENTERPRISE", "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+            "lastUpdatedDate":1501769592000, "creationDate":1501769437000, "address":"10.10.10.0", "netmask":"255.255.255.0", "name":"Subnet 0",
+            "dynamicIpv6Address":true, "gateway":"10.10.10.1", "description":null, "maintenanceMode":"DISABLED", "routeDistinguisher":"65534:61119",
+            "routeTarget":"65534:10022", "vnId":6156324, "underlayEnabled":"INHERITED", "underlay":false, "entityState":null, "splitSubnet":false,
+            "encryption":"INHERITED", "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e", "ID":"debb9f88-f252-4c30-9a17-d6ae3865e365",
+            "parentID":"3b11a2d0-2082-42f1-92db-0b05264f372e", "externalID":null, "IPv6Address":null, "IPType":"IPV4", "IPv6Gateway":null,
+            "serviceID":1635387751, "gatewayMACAddress":"68:54:ED:00:63:E4", "PATEnabled":"INHERITED", "policyGroupID":1855109907, "public":false,
+            "templateID":"aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc", "associatedSharedNetworkResourceID":null, "DHCPRelayStatus":"DISABLED",
+            "proxyARP":false, "multicast":"INHERITED", "associatedMulticastChannelMapID":null, "DPI":"INHERITED", "useGlobalMAC":"DISABLED"},
+          {
+            "children":null, "parentType":"zone", "entityScope":"ENTERPRISE", "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+            "lastUpdatedDate":1501769601000, "creationDate":1501769443000, "address":"10.10.20.0", "netmask":"255.255.255.0", "name":"Subnet 1",
+            "dynamicIpv6Address":true, "gateway":"10.10.20.1", "description":null, "maintenanceMode":"DISABLED", "routeDistinguisher":"65534:25738",
+            "routeTarget":"65534:4633", "vnId":10811344, "underlayEnabled":"INHERITED", "underlay":false, "entityState":null, "splitSubnet":false,
+            "encryption":"INHERITED", "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e", "ID":"d60d316a-c1ac-4412-813c-9652bdbc4e41",
+            "parentID":"6256954b-9dd6-43ed-94ff-9daa683ab8b0", "externalID":null, "IPv6Address":null, "IPType":"IPV4", "IPv6Gateway":null,
+            "serviceID":1809852655, "gatewayMACAddress":"68:54:ED:00:BA:A2", "PATEnabled":"INHERITED", "policyGroupID":1122598490, "public":false,
+            "templateID":null, "associatedSharedNetworkResourceID":null, "DHCPRelayStatus":"DISABLED", "proxyARP":false, "multicast":"INHERITED",
+            "associatedMulticastChannelMapID":null, "DPI":"INHERITED", "useGlobalMAC":"DISABLED"
+          }
+        ]
     http_version: 
   recorded_at: Wed, 23 Aug 2017 15:27:31 GMT
 - request:

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/no_api_interaction.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/no_api_interaction.yml
@@ -1,0 +1,3 @@
+---
+http_interactions: []
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we tackle Nuage glitch that event is not triggered. So when subnet template is deleted, also all the subnets that are connected to it are deleted, but no explicit event is triggered for them hence MIQ does not remove them from VMDB.

Solution: we now capture "subnet template was deleted" event and manually remove all subnets linked to subnet template.

To get things even better: MIQ is currently not inventoring subnet templates nor supports anything like this in its schema. Therefore we abuse `cloud_subnet.extra_attributes` to store subnet template ID in it so that we can later know what subnets are linked to which subnet template.