### PR TITLE
Lock babel because it's in pre-alpha and it's changing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "redux": "^4.0.0"
   },
   "devDependencies": {
+    "@babel/runtime": "7.0.0-beta.42",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
With this commit we lock babel to specific version because it's active development causes Travis failures.

@himdel kindly ask for quick check on this. Thanks!