### PR TITLE
Add missing log file before running tests

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,6 +6,7 @@ gem_root = Pathname.new(__dir__).join("..")
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
+  Dir.mkdir("spec/manageiq/log")
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s


### PR DESCRIPTION
Core repository no longer contains log folder, which needs to be
created manually.

This commit simply ensures that log folder is present when checking
out manageiq core repository into spec folder.