### PR TITLE
Follow `log` directory creation pattern from other providers

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,8 +6,10 @@ gem_root = Pathname.new(__dir__).join("..")
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
-  Dir.mkdir("spec/manageiq/log")
 end
+
+# Ensure a log dir always exists.
+gem_root.join("spec/manageiq/log").mkpath
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_setup(gem_root)


### PR DESCRIPTION
With this commit we further improve `log` directory creation now that it's missing from git. This approach is better than what we had before because

a) it uses absolute path and will work regardless $PWD
b) it's executed everytime bin/setup is run, not just upon
   spec/manageiq link creation

Copied from: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/273

/cc @cben @tadeboro 