### PR TITLE
Revert "Add missing log file before running tests"

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,7 +6,6 @@ gem_root = Pathname.new(__dir__).join("..")
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
-  Dir.mkdir("spec/manageiq/log")
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq/pull/17886 has been merged, no work-around is needed anymore in order to run tests. This pull requests simply removes it from the code base.

@miq-bot assign @miha-plesko 