### PR TITLE
Targeted refresh: remove subnet when zone is removed

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector/target_collection.rb
@@ -179,6 +179,20 @@ class ManageIQ::Providers::Nuage::Inventory::Collector::TargetCollection < Manag
         add_simple_target!(:cloud_subnets, subnet.ems_ref, :options => { :kind => 'L3', :deleted => true })
       end
     end
+
+    references_with_options(:zone_templates).each do |template|
+      next unless template[:operation] == 'DELETE'
+      manager.cloud_subnets_by_extra_attr('zone_template_id', template[:ems_ref]).each do |subnet|
+        add_simple_target!(:cloud_subnets, subnet.ems_ref, :options => { :kind => 'L3', :deleted => true })
+      end
+    end
+
+    references_with_options(:zones).each do |zone|
+      next unless zone[:operation] == 'DELETE'
+      manager.cloud_subnets_by_extra_attr('zone_id', zone[:ems_ref]).each do |subnet|
+        add_simple_target!(:cloud_subnets, subnet.ems_ref, :options => { :kind => 'L3', :deleted => true })
+      end
+    end
   end
 
   def infer_related_ems_refs_api!

--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -132,9 +132,10 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
   def map_extra_attributes(zone_id)
     if (zone = collector.zone(zone_id))
       {
-        'domain_id' => zone['parentID'],
-        'zone_name' => zone['name'],
-        'zone_id'   => zone_id
+        'domain_id'        => zone['parentID'],
+        'zone_name'        => zone['name'],
+        'zone_id'          => zone_id,
+        'zone_template_id' => zone['templateID']
       }
     else
       {}

--- a/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_target_parser.rb
@@ -50,6 +50,12 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventTargetParser
     when 'subnettemplate'
       add_targets(target_collection, :cloud_subnet_templates, event.full_data['entities'],
                   :options => { :operation => event_operation(event) })
+    when 'zonetemplate'
+      add_targets(target_collection, :zone_templates, event.full_data['entities'],
+                  :options => { :operation => event_operation(event) })
+    when 'zone'
+      add_targets(target_collection, :zones, event.full_data['entities'],
+                  :options => { :operation => event_operation(event) })
     end
 
     target_collection.targets

--- a/spec/models/manageiq/providers/nuage/network_manager/inventory_parser_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/inventory_parser_spec.rb
@@ -25,12 +25,13 @@ describe ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager do
     end
 
     context 'regular case' do
-      let(:zone) { { 'name' => 'Zone Name', 'parentID' => 'domain-id' } }
+      let(:zone) { { 'name' => 'Zone Name', 'parentID' => 'domain-id', 'templateID' => 'template-id' } }
       it 'invoke' do
         expect(subject.send(:map_extra_attributes, 'the-zone')).to eq(
-          'domain_id'       => 'domain-id',
-          'zone_name'       => 'Zone Name',
-          'zone_id'         => 'the-zone'
+          'domain_id'        => 'domain-id',
+          'zone_name'        => 'Zone Name',
+          'zone_id'          => 'the-zone',
+          'zone_template_id' => 'template-id'
         )
       end
     end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -65,7 +65,6 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     let(:vm_port_ref)         { "15d1369e-9553-4e83-8bb9-3a6c269f81ae" }
     let(:bridge_port_ref)     { "43b7faad-2c76-4945-9412-66a04bde7b6a" }
     let(:host_port_ref)       { "b19075d3-a797-4dcd-93be-de52b4247e46" }
-    let(:subnet_template_ref) { "aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc" }
 
     ALL_REFRESH_SETTINGS.each do |settings|
       context "with settings #{settings}" do
@@ -202,10 +201,11 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
-        "domain_id"   => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
-        "zone_name"   => "Zone 1",
-        "zone_id"     => "6256954b-9dd6-43ed-94ff-9daa683ab8b0",
-        "template_id" => nil
+        "domain_id"        => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
+        "zone_name"        => "Zone 1",
+        "zone_id"          => "6256954b-9dd6-43ed-94ff-9daa683ab8b0",
+        "template_id"      => nil,
+        "zone_template_id" => nil
       }
     )
 
@@ -228,10 +228,11 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :network_router_id              => NetworkRouter.find_by(:ems_ref => router_ref).id,
       :parent_cloud_subnet_id         => nil,
       :extra_attributes               => {
-        "domain_id"   => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
-        "zone_name"   => "Zone 0",
-        "zone_id"     => "3b11a2d0-2082-42f1-92db-0b05264f372e",
-        "template_id" => "aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc"
+        "domain_id"        => "75ad8ee8-726c-4950-94bc-6a5aab64631d",
+        "zone_name"        => "Zone 0",
+        "zone_id"          => "3b11a2d0-2082-42f1-92db-0b05264f372e",
+        "template_id"      => "aaaaaaaa-aaaa-bbbb-bbbb-cccccccccccc",
+        "zone_template_id" => "abababab-abab-abab-abab-abababababab"
       }
     )
   end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
@@ -286,26 +286,71 @@ http_interactions:
       - application/json
       Transfer-Encoding:
       - chunked
-      Content-Encoding:
-      - gzip
       Vary:
       - Accept-Encoding
       Date:
       - Wed, 23 Aug 2017 15:27:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAANVTTY/TMBD9K8jnWnIS20l626URa4kuVVs4gDiMP6KNSJwo
-        cYAI8d8Zd7esCgiBxIG9RPLMvOfxey/vvhBz17R2dJ6s/dy2KzIAHsJxGRxZ
-        E9t30HiyIlhqwnIw/alc3R6r/W6vDhW2WpjC68FCcPZ6wWYBsmYuZRS41ZQX
-        eUHBFpyWxsgkF9JY4S5hG/yQdSJYksuSZwljbEXM6CA0vf9lEyyuPE3nnb0L
-        HUwfvh+hi1u+7b17xvAqu2ClMWr4KK8ugdZNZmyGeM+5FB8cnAdv3La3kWej
-        DlfXL6sNMg2zbhsTicm6hnZyURkzLg8MRN3eVHt1PM32n7wb/1wPtcHZTCcJ
-        pJbRlBUp5Wmd0DJFFNNMpJLXWZ7G2XuPTohcIJlzBc1TaSgvBaMl14ZKEABa
-        cpklNvr3ObjRQxsx9+9Uu5/UULsH29XuDUeQnzvtxlf1TT+FSfnDrFFonEYD
-        guuGFp155Bt6VGZ5MfbzEItJXhasEDy61c1taAz6/YNCME29aWICtueJ53fg
-        vWu3MDwyb3bqAvh19T+mNvtdarO/TG3ypFIrUyFLwTUtrZWUZ85iBusajwCy
-        yEAXmj2R1JZCMM7w7/v3qX3/DYzOjy9tBQAA
+      string: |
+        [
+           {
+              "children":null,
+              "parentType":"domain",
+              "entityScope":"ENTERPRISE",
+              "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+              "lastUpdatedDate":1501769431000,
+              "creationDate":1501769431000,
+              "address":null,
+              "netmask":null,
+              "name":"Zone 0",
+              "dynamicIpv6Address":null,
+              "description":null,
+              "maintenanceMode":"DISABLED",
+              "publicZone":false,
+              "encryption":"INHERITED",
+              "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+              "ID":"3b11a2d0-2082-42f1-92db-0b05264f372e",
+              "parentID":"75ad8ee8-726c-4950-94bc-6a5aab64631d",
+              "externalID":null,
+              "IPv6Address":null,
+              "IPType":"IPV4",
+              "numberOfHostsInSubnets":0,
+              "templateID":"abababab-abab-abab-abab-abababababab",
+              "policyGroupID":1798085400,
+              "multicast":"INHERITED",
+              "associatedMulticastChannelMapID":null,
+              "DPI":"INHERITED"
+           },
+           {
+              "children":null,
+              "parentType":"domain",
+              "entityScope":"ENTERPRISE",
+              "lastUpdatedBy":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+              "lastUpdatedDate":1501769433000,
+              "creationDate":1501769433000,
+              "address":null,
+              "netmask":null,
+              "name":"Zone 1",
+              "dynamicIpv6Address":null,
+              "description":null,
+              "maintenanceMode":"DISABLED",
+              "publicZone":false,
+              "encryption":"INHERITED",
+              "owner":"8a6f0e20-a4db-4878-ad84-9cc61756cd5e",
+              "ID":"6256954b-9dd6-43ed-94ff-9daa683ab8b0",
+              "parentID":"75ad8ee8-726c-4950-94bc-6a5aab64631d",
+              "externalID":null,
+              "IPv6Address":null,
+              "IPType":"IPV4",
+              "numberOfHostsInSubnets":0,
+              "templateID":null,
+              "policyGroupID":1955040208,
+              "multicast":"INHERITED",
+              "associatedMulticastChannelMapID":null,
+              "DPI":"INHERITED"
+           }
+        ]
     http_version: 
   recorded_at: Wed, 23 Aug 2017 15:27:30 GMT
 - request:


### PR DESCRIPTION
There is a known Nuage glitch that some events are not being emitted. With this commit we tackle the one that when zone or zone template are deleted, also all the subnets in it are deleted, but MIQ has no idea about it. So we need to play smart: when recieveing either of

```
nuage_zonetemplate_delete
nuage_zone_delete
```

events, we manually mark also all corresponding subnets for deletion.