### PR TITLE
Connect SecurityGroup to NetworkRouter/CloudSubnet

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet < ::CloudSubnet
+  has_many :security_groups, :dependent => :destroy
+
   include AnsibleCrudMixin
 
   before_destroy :remove_network_ports, :prepend => true

--- a/app/models/manageiq/providers/nuage/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/network_router.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Nuage::NetworkManager::NetworkRouter < ::NetworkRouter
   has_many :floating_ips,  :dependent => :destroy
   has_many :cloud_subnets, :dependent => :destroy
+  has_many :security_groups, :dependent => :destroy
 end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -54,6 +54,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     let(:tenant_ref1)         { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
     let(:tenant_ref2)         { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }
     let(:security_group_ref)  { "02e072ef-ca95-4164-856d-3ff177b9c13c" }
+    let(:security_group_ref2) { "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }
     let(:cloud_subnet_ref1)   { "d60d316a-c1ac-4412-813c-9652bdbc4e41" }
     let(:cloud_subnet_ref2)   { "debb9f88-f252-4c30-9a17-d6ae3865e365" }
     let(:l2_subnet_ref1)      { "3b733a41-774d-4aaa-8e64-588d5533a5c0" }
@@ -105,7 +106,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     expect(ExtManagementSystem.count).to eq(1)
     expect(CloudTenant.count).to eq(2)
     expect(CloudNetwork.count).to eq(1)
-    expect(SecurityGroup.count).to eq(1)
+    expect(SecurityGroup.count).to eq(2)
     expect(CloudSubnet.count).to eq(6)
     expect(FloatingIp.count).to eq(3)
     expect(NetworkPort.count).to eq(4)
@@ -114,7 +115,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
 
   def assert_ems
     expect(@ems.cloud_tenants.count).to eq(2)
-    expect(@ems.security_groups.count).to eq(1)
+    expect(@ems.security_groups.count).to eq(2)
     expect(@ems.cloud_subnets.count).to eq(6)
     expect(@ems.l3_cloud_subnets.count).to eq(2)
     expect(@ems.l2_cloud_subnets.count).to eq(4)
@@ -122,7 +123,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     expect(@ems.cloud_tenants.map(&:ems_ref))
       .to match_array([tenant_ref1, tenant_ref2])
     expect(@ems.security_groups.map(&:ems_ref))
-      .to match_array([security_group_ref])
+      .to match_array([security_group_ref, security_group_ref2])
     expect(@ems.l3_cloud_subnets.map(&:ems_ref))
       .to match_array([cloud_subnet_ref1, cloud_subnet_ref2])
   end
@@ -150,12 +151,12 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     expect(g2.cloud_subnets.count).to eq(4)
     expect(g2.l3_cloud_subnets.count).to eq(2)
     expect(g2.l2_cloud_subnets.count).to eq(2)
-    expect(g2.security_groups.count).to eq(1)
+    expect(g2.security_groups.count).to eq(2)
 
     expect(g2.l3_cloud_subnets.map(&:ems_ref))
       .to match_array([cloud_subnet_ref1, cloud_subnet_ref2])
     expect(g2.security_groups.map(&:ems_ref))
-      .to match_array([security_group_ref])
+      .to match_array([security_group_ref, security_group_ref2])
   end
 
   def assert_network_routers
@@ -177,7 +178,22 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
       :ems_id                 => @ems.id,
       :cloud_network_id       => nil,
       :cloud_tenant_id        => CloudTenant.find_by(:ems_ref => tenant_ref2).id,
-      :orchestration_stack_id => nil
+      :orchestration_stack_id => nil,
+      :network_router         => NetworkRouter.find_by(:ems_ref => router_ref),
+      :cloud_subnet           => nil
+    )
+
+    g2 = SecurityGroup.find_by(:ems_ref => security_group_ref2)
+    expect(g2).to have_attributes(
+      :name                   => "Policy Group on L2",
+      :description            => nil,
+      :type                   => "ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup",
+      :ems_id                 => @ems.id,
+      :cloud_network_id       => nil,
+      :cloud_tenant_id        => CloudTenant.find_by(:ems_ref => tenant_ref2).id,
+      :orchestration_stack_id => nil,
+      :network_router         => nil,
+      :cloud_subnet           => CloudSubnet.find_by(:ems_ref => l2_subnet_ref2)
     )
   end
 

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -354,6 +354,22 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
                 assert_deleted(cloud_subnet)
               end
             end
+
+            it "security_group is deleted if its network_router is deleted" do
+              security_group.tap { |group| group.network_router = network_router }.save
+              test_targeted_refresh([network_router], 'network_router_is_deleted', :repeat => 1) do
+                assert_deleted(network_router)
+                assert_deleted(security_group)
+              end
+            end
+
+            it "security_group is deleted if its cloud_subnet is deleted" do
+              security_group.tap { |group| group.cloud_subnet = cloud_subnet }.save
+              test_targeted_refresh([cloud_subnet], 'cloud_subnet_is_deleted', :repeat => 1) do
+                assert_deleted(cloud_subnet)
+                assert_deleted(security_group)
+              end
+            end
           end
         end
       end

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
@@ -600,23 +600,55 @@ http_interactions:
       - application/json
       Transfer-Encoding:
       - chunked
-      Content-Encoding:
-      - gzip
       Vary:
       - Accept-Encoding
       Date:
       - Wed, 23 Aug 2017 15:27:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAI1QzU+DMBz9V5aeadJCP4CbOjS7zGVDPRgPpf2hJKUQ6KLE
-        +L9bWNSZePDSpO+jfe89viP90lgzgEO5O1oboV6Fiy+nHlCOTNeqxqEIBajx
-        00F3C1xsy2K/228ORaCsGv1db5QHczkFkhutZS1iLCtGMKMyw5WpaxyLqoY0
-        g4rE7LdtHQ6UU04SwmlGE0JIhPQAyjed+5N0qp1zlDD61a6zjZ5WN0N37MO7
-        BkY9NP1snZO2vZ9W51iE/Knb4fa6fLjYzxXgzcPglEV5rewI33X98vdpl+7V
-        wfD/ept10JIYiIyhxlplPGgFwykXBid1TaWsMk0Tjb4mXxySK5MCpFjGQmOW
-        cYIzVmksFFeqEkwk1JwFnj2neMX9bnvVte3RheClev7CPbS9DTV+lP2y1zLX
-        DFKRxYmUKUs/nj4B8q6H7Q8CAAA=
+      string: |
+        [
+           {
+              "children":null,
+              "parentType":"domain",
+              "entityScope":"ENTERPRISE",
+              "lastUpdatedBy":"5dcc7f62-7b40-4179-bdff-26bfe89eb024",
+              "lastUpdatedDate":1503051913000,
+              "creationDate":1503051913000,
+              "name":"Test Policy Group",
+              "description":"Empty description",
+              "type":"SOFTWARE",
+              "external":false,
+              "entityState":null,
+              "owner":"5dcc7f62-7b40-4179-bdff-26bfe89eb024",
+              "ID":"02e072ef-ca95-4164-856d-3ff177b9c13c",
+              "parentID":"75ad8ee8-726c-4950-94bc-6a5aab64631d",
+              "externalID":null,
+              "EVPNCommunityTag":null,
+              "templateID":null,
+              "policyGroupID":1692377848
+           },
+          {
+            "children":null,
+            "parentType":"l2domain",
+            "entityScope":"ENTERPRISE",
+            "lastUpdatedBy":"5dcc7f62-7b40-4179-bdff-26bfe89eb024",
+            "lastUpdatedDate":1503051913000,
+            "creationDate":1503051913000,
+            "name":"Policy Group on L2",
+            "description":"Empty description",
+            "type":"SOFTWARE",
+            "external":false,
+            "entityState":null,
+            "owner":"5dcc7f62-7b40-4179-bdff-26bfe89eb024",
+            "ID":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "parentID":"8efc78b0-df2a-4c6f-964b-463a9d106bed",
+            "externalID":null,
+            "EVPNCommunityTag":null,
+            "templateID":null,
+            "policyGroupID":123456
+          }
+        ]
     http_version: 
   recorded_at: Wed, 23 Aug 2017 15:27:31 GMT
 - request:


### PR DESCRIPTION
With this commit we perform two things:

- inventoring now fetches relation to parent of the SecurityGroup (can   be either NetworkRouter (L3 domain) or CloudSubnet::L2 (L2 Domain))
- set `:destroy => :dependent` because when parent is deleted, SecurityGroup is always deleted as well