### PR TITLE
Cross-connect NetworkPorts by `vm.uid_ems`

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser/network_manager.rb
@@ -131,7 +131,7 @@ class ManageIQ::Providers::Nuage::Inventory::Parser::NetworkManager < ManageIQ::
       end
 
       network_port.type = network_port_type
-      network_port.device = persister.vms.lazy_find(vm_ref)
+      network_port.device = persister.vms.lazy_find({ :uid_ems => vm_ref }, { :ref => :by_uid_ems }) if vm_ref
       network_port.cloud_subnet_network_ports = [
         persister.cloud_subnet_network_ports.find_or_build_by(
           :cloud_subnet => persister.cloud_subnets.lazy_find(port['parentID']),

--- a/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
@@ -29,9 +29,10 @@ module ManageIQ::Providers::Nuage::Inventory::Persister::Definitions::NetworkCol
   def add_cross_provider_vms
     add_collection(cloud, :vms) do |builder|
       builder.add_properties(
-        :arel        => Vm.all,
-        :strategy    => :local_db_find_references,
-        :association => nil
+        :arel           => Vm.all,
+        :strategy       => :local_db_find_references,
+        :association    => nil,
+        :secondary_refs => { :by_uid_ems => %i(uid_ems) }
       )
     end
   end

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -51,8 +51,8 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   describe "refresh" do
-    let(:ems_amazon)          { FactoryGirl.create(:ems_amazon) }
-    let!(:vm_amazon)          { FactoryGirl.create(:vm_amazon, :ems_id => ems_amazon.id, :ems_ref => 'ref-amazon-vm') }
+    let(:ems_vmware)          { FactoryGirl.create(:ems_vmware) }
+    let!(:vm_vmware)          { FactoryGirl.create(:vm_vmware, :ems_id => ems_vmware.id, :uid_ems => 'ref-vmware-vm') }
     let(:tenant_ref1)         { "713d0ba0-dea8-44b4-8ac7-6cab9dc321a7" }
     let(:tenant_ref2)         { "e0819464-e7fc-4a37-b29a-e72da7b5956c" }
     let(:security_group_ref)  { "02e072ef-ca95-4164-856d-3ff177b9c13c" }
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ExtManagementSystem.count).to eq(1 + 3) # nuage + 3*amazon (cloud, network, storage manager)
+    expect(ExtManagementSystem.count).to eq(1 + 1) # nuage + vmware infra
     expect(CloudTenant.count).to eq(2)
     expect(CloudNetwork.count).to eq(1)
     expect(SecurityGroup.count).to eq(2)
@@ -332,7 +332,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
     )
 
     # Check VM was cross-provider connected
-    expect(vm_port.device).to eq(vm_amazon)
+    expect(vm_port.device).to eq(vm_vmware)
 
     bridge_port = NetworkPort.find_by(:ems_ref => bridge_port_ref)
     expect(bridge_port).to have_attributes(

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher.yml
@@ -2958,7 +2958,7 @@ http_interactions:
             "ID": "4d2c2b5d-5c15-4462-a376-53540ddba69c",
             "parentID": null,
             "externalID": null,
-            "UUID": "ref-amazon-vm",
+            "UUID": "ref-vmware-vm",
             "status": "INIT",
             "reasonType": null,
             "hypervisorIP": "FFFFFF",

--- a/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_port_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/nuage/network_manager/refresher_targeted/network_port_vm.yml
@@ -340,7 +340,7 @@ http_interactions:
             "ID": "4d2c2b5d-5c15-4462-a376-53540ddba69c",
             "parentID": null,
             "externalID": null,
-            "UUID": "ref-amazon-vm",
+            "UUID": "ref-vmware-vm",
             "status": "INIT",
             "reasonType": null,
             "hypervisorIP": "FFFFFF",


### PR DESCRIPTION
Until now we were connecting NetworkPorts to VM by vm.ems_ref, but turns out Nuage vPort actually contains UUID value of the VM which is stored as

```
vm.uid_ems
```

Usecase we're testing it on is for VMware vCenter VM's while other providers (who might actually have the UUID stored in `vm.ems_ref`) are currently not of high priority to Nuage.

With this commit we switch matching from `ems_ref` to `uid_ems`.

Screenshot how vCenter VMs are now cross-connected to Nuage vports (a VM can be connected to more than one vPort):

![image](https://user-images.githubusercontent.com/8102426/46349163-963c8780-c651-11e8-8fcd-41c2fea7ef89.png)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1635232
