### PR TITLE
Travis - change postgres to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   - rvm: 2.3.6
     env: TEST_SUITE=yarn:test
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 before_install: bin/qpid_install.sh
 install:
 - bin/setup


### PR DESCRIPTION
Upgrading postgres to 9.5 on travis.

Related to https://github.com/ManageIQ/manageiq/pull/18090

@miq-bot add_label hammer/yes