### PR TITLE
Raise error when built-in CRUD playbook fails

### DIFF
--- a/app/models/manageiq/providers/nuage/ansible_crud_mixin.rb
+++ b/app/models/manageiq/providers/nuage/ansible_crud_mixin.rb
@@ -7,12 +7,13 @@ module ManageIQ::Providers::Nuage::AnsibleCrudMixin
     end
 
     def ansible_raise_for_status(ansible_response)
+      $nuage_log.debug("Ansible response:\n#{ansible_outputs(ansible_response)}")
       # TODO: introduce new error type say MiqException::AnsibleReturnCodeError
       raise MiqException::Error, ansible_outputs(ansible_response) unless ansible_response.return_code.zero?
     end
 
     def ansible_outputs(ansible_response)
-      "Playbook failed with return code #{ansible_response.return_code}\n" + \
+      "Playbook finished with return code #{ansible_response.return_code}\n" + \
         ansible_response.parsed_stdout.map { |line| line['stdout'].to_s.strip }.join("\n")
     end
   end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet < ::CloudSubnet
   has_many :security_groups, :dependent => :destroy
 
-  include AnsibleCrudMixin
+  include ManageIQ::Providers::Nuage::AnsibleCrudMixin
 
   before_destroy :remove_network_ports, :prepend => true
 
@@ -32,11 +32,12 @@ class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet < ::CloudSubnet
   def raw_delete_cloud_subnet
     $nuage_log.info("Deleting Cloud Subnet (ems_ref = #{ems_ref})")
 
-    Ansible::Runner.run(
+    response = Ansible::Runner.run(
       ext_management_system.ansible_env_vars,
       ext_management_system.ansible_extra_vars(:id => ems_ref, :kind => kind),
       ext_management_system.playbook('remove-subnet.yml')
     )
+    self.class.ansible_raise_for_status(response)
 
     $nuage_log.info("Done deleting Cloud Subnet (ems_ref = #{ems_ref})")
   rescue StandardError => e

--- a/app/models/manageiq/providers/nuage/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/floating_ip.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Nuage::NetworkManager::FloatingIp < ::FloatingIp
+  include ManageIQ::Providers::Nuage::AnsibleCrudMixin
+
   supports :delete
 
   def delete_floating_ip_queue(userid)
@@ -26,11 +28,12 @@ class ManageIQ::Providers::Nuage::NetworkManager::FloatingIp < ::FloatingIp
   def raw_delete_floating_ip
     $nuage_log.info("Deleting Floating Ip (ems_ref = #{ems_ref})")
 
-    Ansible::Runner.run(
+    response = Ansible::Runner.run(
       ext_management_system.ansible_env_vars,
       ext_management_system.ansible_extra_vars(:id => ems_ref),
       ext_management_system.playbook('remove-floating-ip.yml')
     )
+    self.class.ansible_raise_for_status(response)
 
     $nuage_log.info("Done deleting Floating Ip (ems_ref = #{ems_ref})")
   rescue StandardError => e

--- a/app/models/manageiq/providers/nuage/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/security_group.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup < ::SecurityGroup
+  include ManageIQ::Providers::Nuage::AnsibleCrudMixin
+
   supports :delete
 
   def delete_security_group_queue(userid)
@@ -26,11 +28,12 @@ class ManageIQ::Providers::Nuage::NetworkManager::SecurityGroup < ::SecurityGrou
   def raw_delete_security_group
     $nuage_log.info("Deleting Security Group (ems_ref = #{ems_ref})")
 
-    Ansible::Runner.run(
+    response = Ansible::Runner.run(
       ext_management_system.ansible_env_vars,
       ext_management_system.ansible_extra_vars(:id => ems_ref),
       ext_management_system.playbook('remove-policy-group.yml')
     )
+    self.class.ansible_raise_for_status(response)
 
     $nuage_log.info("Done deleting Security Group (ems_ref = #{ems_ref})")
   rescue StandardError => e

--- a/spec/models/manageiq/providers/nuage/network_manager/floating_ip_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/floating_ip_spec.rb
@@ -1,7 +1,9 @@
 describe ManageIQ::Providers::Nuage::NetworkManager::FloatingIp do
-  let(:ems)  { FactoryGirl.create(:ems_nuage_network_with_authentication, :api_version => 'v5.0') }
-  let(:user) { 123 }
-  let(:job)  { MiqQueue.find_by(:method_name => 'delete_floating_ip') }
+  let(:ems)          { FactoryGirl.create(:ems_nuage_network_with_authentication, :api_version => 'v5.0') }
+  let(:user)         { 123 }
+  let(:job)          { MiqQueue.find_by(:method_name => 'delete_floating_ip') }
+  let(:response_ok)  { double('ansible_response', :return_code => 0, :parsed_stdout => []) }
+  let(:response_bad) { double('ansible_response', :return_code => 2, :parsed_stdout => []) }
 
   subject do
     FactoryGirl.create(
@@ -25,14 +27,22 @@ describe ManageIQ::Providers::Nuage::NetworkManager::FloatingIp do
     )
   end
 
-  it '.delete_floating_ip' do
-    expect(Ansible::Runner).to receive(:run) do |env, vars, playbook|
-      expect(env).to be_empty
-      expect(vars.keys).to eq(%i(nuage_auth id))
-      expect(vars[:id]).to eq(subject.ems_ref)
-      expect(playbook.to_s).to end_with("/remove-floating-ip.yml")
-      expect(File).to exist(playbook.to_s)
+  describe '.delete_floating_ip' do
+    it 'happy path' do
+      expect(Ansible::Runner).to receive(:run) do |env, vars, playbook|
+        expect(env).to be_empty
+        expect(vars.keys).to eq(%i(nuage_auth id))
+        expect(vars[:id]).to eq(subject.ems_ref)
+        expect(playbook.to_s).to end_with("/remove-floating-ip.yml")
+        expect(File).to exist(playbook.to_s)
+
+        response_ok
+      end
+      subject.delete_floating_ip
     end
-    subject.delete_floating_ip
+
+    it 'bad playbook status' do
+      raises_upon_errored_playbook { subject.delete_floating_ip }
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,9 @@ end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::Nuage::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
+
+# Utility function to test Ansible::runner bad status handling
+def raises_upon_errored_playbook
+  expect(Ansible::Runner).to receive(:run).and_return(response_bad)
+  expect { yield }.to raise_error(MiqException::Error)
+end


### PR DESCRIPTION
With this commit we make sure every Ansible::Runner command is followed by "ansible_raise_for_status" check that raises error when playbook execution errored.

Also, we add playbook logging regardless its execution success/failure, but on debug level. This way we will be able to see playbook outputs in log/nuage.log, when desired.

Screenshot of

```
less -r log/nuage.log
```

![image](https://user-images.githubusercontent.com/8102426/47554811-7fb0e580-d90a-11e8-880a-682d31e429c5.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1642472