### PR TITLE
Fix spec failures for ems counts

### DIFF
--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ExtManagementSystem.count).to eq(1 + 1) # nuage + vmware infra
+    expect(ExtManagementSystem.count).to eq(3) # nuage + vmware infra
     expect(CloudTenant.count).to eq(2)
     expect(CloudNetwork.count).to eq(1)
     expect(SecurityGroup.count).to eq(2)

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -425,7 +425,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_cloud_subnet_counts
-    expect(ExtManagementSystem.count).to eq(1)
+    expect(ExtManagementSystem.count).to eq(2)
     expect(CloudTenant.count).to eq(0)
     expect(SecurityGroup.count).to eq(0)
     expect(CloudSubnet.count).to eq(1)
@@ -464,7 +464,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_cloud_tenant_counts
-    expect(ExtManagementSystem.count).to eq(1)
+    expect(ExtManagementSystem.count).to eq(2)
     expect(CloudTenant.count).to eq(1)
     expect(SecurityGroup.count).to eq(0)
     expect(CloudSubnet.count).to eq(0)
@@ -485,7 +485,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_security_group_counts
-    expect(ExtManagementSystem.count).to eq(1)
+    expect(ExtManagementSystem.count).to eq(2)
     expect(CloudTenant.count).to eq(0)
     expect(SecurityGroup.count).to eq(1)
     expect(CloudSubnet.count).to eq(0)


### PR DESCRIPTION
So these counts needed to be adjusted to reflect that ems leaf classes have the inheritance set when you use the factory. 

🤷‍♀ 

I can't even actually run specs here at all, because of this:
An error occurred while loading spec_helper.
Failure/Error: require 'qpid_proton'

LoadError:
  cannot load such file -- qpid_proton

but it's highly likely that's just me. 