### PR TITLE
Implement relations that are typically delegated to cloud manager

### DIFF
--- a/app/models/manageiq/providers/nuage/cloud_delegates_mixin.rb
+++ b/app/models/manageiq/providers/nuage/cloud_delegates_mixin.rb
@@ -1,0 +1,58 @@
+module ManageIQ::Providers::Nuage::CloudDelegatesMixin
+  def flavors
+    Flavor.none
+  end
+
+  def cloud_resource_quotas
+    CloudResourceQuota.none
+  end
+
+  def cloud_volumes
+    CloudVolume.none
+  end
+
+  def cloud_volume_snapshots
+    CloudVolumeSnapshot.none
+  end
+
+  def cloud_object_store_containers
+    CloudObjectStoreContainer.none
+  end
+
+  def cloud_object_store_objects
+    CloudObjectStoreObject.none
+  end
+
+  def key_pairs
+    ManageIQ::Providers::CloudManager::AuthKeyPair.none
+  end
+
+  def orchestration_stacks
+    OrchestrationStack.none
+  end
+  alias direct_orchestration_stacks orchestration_stacks
+
+  def orchestration_stacks_resources
+    OrchestrationStackResource.none
+  end
+
+  def resource_groups
+    ResourceGroup.none
+  end
+
+  def vms
+    Vm.none
+  end
+  alias total_vms vms
+  alias vms_and_templates vms
+  alias total_vms_and_templates vms
+
+  def miq_templates
+    MiqTemplate.none
+  end
+  alias total_miq_templates miq_templates
+
+  def hosts
+    Host.none
+  end
+end

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
 
   include Vmdb::Logging
   include ManageIQ::Providers::Nuage::ManagerMixin
+  include ManageIQ::Providers::Nuage::CloudDelegatesMixin
 
   def self.ems_type
     @ems_type ||= "nuage_network".freeze

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -294,4 +294,31 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
       expect(ems.playbook('play.yaml').to_s).to end_with('/manageiq-providers-nuage/content/ansible_runner/play.yaml')
     end
   end
+
+  describe 'delegates that usually point to cloud manager' do
+    %i[
+      flavors
+      cloud_resource_quotas
+      cloud_volumes
+      cloud_volume_snapshots
+      cloud_object_store_containers
+      cloud_object_store_objects
+      key_pairs
+      orchestration_stacks
+      orchestration_stacks_resources
+      direct_orchestration_stacks
+      resource_groups
+      vms
+      total_vms
+      vms_and_templates
+      total_vms_and_templates
+      miq_templates
+      total_miq_templates
+      hosts
+    ].each do |rel|
+      it "##{rel}" do
+        expect(subject.send(rel).count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Nuage provider is a bit special because it's a network provider only without cloud provider. This brings some problems with delegates that are specified for network manager by default (like .hosts) because they always get resolved as `nil` instead as empty queryset. Some parts of code don't check for nil, like metrics collector:

https://github.com/ManageIQ/manageiq/blob/master/app/models/metric/targets.rb#L98

```
ems.hosts.each { ... } # BOOOM because hosts is nil
```

so the code explodes. With this commit we "fake" all delegates so that they now return empty querysets.

```
ems.hosts.each { ... } # skips because hosts is empty queryset
```

/cc @pdellaert @gberginc 