### PR TITLE
[IVANCHUK] Unittest .travis.yml to ensure excludes match the matrix

### DIFF
--- a/spec/other/travis_spec.rb
+++ b/spec/other/travis_spec.rb
@@ -1,0 +1,19 @@
+describe 'travis.yml' do
+  let(:travis) { YAML.safe_load(File.open(ManageIQ::Providers::Nuage::Engine.root.join('.travis.yml'))) }
+  let(:versions) { travis['rvm'] }
+
+  it "matches versions and excludes for multiple ruby versions" do
+    if versions.length > 1
+      excludes = travis.dig('matrix', 'exclude').map { |ex| ex['rvm'] }.sort.uniq
+      expect(excludes.length).to eq(versions.length - 1)
+      expect(versions).to include(excludes.first)
+    end
+  end
+
+  it "does not exclude any testsuite for single ruby version" do
+    if versions.length == 1
+      excludes = travis.dig('matrix', 'exclude')
+      expect(excludes).to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
When we're shifting supported ruby versions we often forget to update the "excludes" block which in turn means we're then re-running javascript tests more than we need to. Now, there is no big harm in re-running the test more than once, but still.

With this commit we unit test that excludes block matches values from the matrix. The rspec is actually copy-pasted from ui-classic repo (thanks @himdel and @mzazrivec )