### PR TITLE
Update the excludes block in .travis.yml

### DIFF
--- a/spec/other/travis_spec.rb
+++ b/spec/other/travis_spec.rb
@@ -1,0 +1,19 @@
+describe 'travis.yml' do
+  let(:travis) { YAML.safe_load(File.open(ManageIQ::Providers::Nuage::Engine.root.join('.travis.yml'))) }
+  let(:versions) { travis['rvm'] }
+
+  it "matches versions and excludes for multiple ruby versions" do
+    if versions.length > 1
+      excludes = travis.dig('matrix', 'exclude').map { |ex| ex['rvm'] }.sort.uniq
+      expect(excludes.length).to eq(versions.length - 1)
+      expect(versions[0..-2]).to eq(excludes)
+    end
+  end
+
+  it "does not exclude any testsuite for single ruby version" do
+    if versions.length == 1
+      excludes = travis.dig('matrix', 'exclude')
+      expect(excludes).to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
With this PR we first update the .travis.yml so that it now matches the actual value from `matrix`. Then we implement unit test to ensure mismatch won't happen again in the future (rspec is copy-pasted from ui-classic repo) 