### PR TITLE
Update the excludes block in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - TEST_SUITE=yarn:test
 matrix:
   exclude:
-  - rvm: 2.3.6
+  - rvm: 2.4.6
     env: TEST_SUITE=yarn:test
 addons:
   postgresql: '10'


### PR DESCRIPTION
There was a mismatch between matrix and excludes block which caused javascript tests be run two times (which is overkill). Not anymore.

/cc @himdel 