### PR TITLE
Remove gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_Nuage',
-  ManageIQ::Providers::Nuage::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
There's no need for the plugin to initialize its own catalog anymore.