### PR TITLE
Remove to_json from toolbar data as it's not needed

### DIFF
--- a/app/helpers/manageiq/providers/nuage/toolbar_overrides/network_router_center.rb
+++ b/app/helpers/manageiq/providers/nuage/toolbar_overrides/network_router_center.rb
@@ -21,7 +21,7 @@ module ManageIQ
                                'function-data' => {:controller     => 'provider_dialogs',
                                                    :button         => :nuage_create_cloud_subnet,
                                                    :modal_title    => N_('Create L3 Cloud Subnet'),
-                                                   :component_name => 'CreateNuageCloudSubnetForm'}.to_json},
+                                                   :component_name => 'CreateNuageCloudSubnetForm'}},
                     :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                 ]


### PR DESCRIPTION
After ManageIQ/manageiq-ui-classic#5997 `to_json` is not needed and will break the data format.

Related to ManageIQ/manageiq-ui-classic#6289 fix but **not** dependent either way.

Before:
Button `Create L3 Cloud Subnet` doesn't work on click.
After:
Button works as expected.

@miq-bot add_label ivanchuk/no