### PR TITLE
Remove inventory refresh from settings

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -36,6 +36,10 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
     %w(default amqp)
   end
 
+  def inventory_object_refresh?
+    true
+  end
+
   def supports_authentication?(authtype)
     supported_auth_types.include?(authtype.to_s)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,7 +24,6 @@
     :user:
 :ems_refresh:
   :nuage_network:
-    :inventory_object_refresh: true
     :allow_targeted_refresh: true
 :workers:
   :worker_base:


### PR DESCRIPTION
Remove inventory_object_refresh from settings as part of the effort to remove the old legacy EmsRefresh and save_inventory refresh code.