### PR TITLE
Don't include repo name in ansible root check

### DIFF
--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -287,11 +287,11 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
     end
 
     it '.ansible_root' do
-      expect(ems.ansible_root.to_s).to end_with('content/ansible_runner')
+      expect(ems.ansible_root.to_s).to end_with('/content/ansible_runner')
     end
 
     it '.playbook' do
-      expect(ems.playbook('play.yaml').to_s).to end_with('content/ansible_runner/play.yaml')
+      expect(ems.playbook('play.yaml').to_s).to end_with('/content/ansible_runner/play.yaml')
     end
   end
 end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -287,11 +287,11 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
     end
 
     it '.ansible_root' do
-      expect(ems.ansible_root.to_s).to end_with('/manageiq-providers-nuage/content/ansible_runner')
+      expect(ems.ansible_root.to_s).to end_with('content/ansible_runner')
     end
 
     it '.playbook' do
-      expect(ems.playbook('play.yaml').to_s).to end_with('/manageiq-providers-nuage/content/ansible_runner/play.yaml')
+      expect(ems.playbook('play.yaml').to_s).to end_with('content/ansible_runner/play.yaml')
     end
   end
 end


### PR DESCRIPTION
This is a minor adjustment to the `ems.ansible_root.to_s` test. I removed the git repo parent directory check since it could actually be anything, and caused failures for me locally since I tend to append my git repos with "-djberg96". Presumably it's only what's beneath it that really matters.