### PR TITLE
Use :payload instead of :data, set :proxy, in Rest class

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client/rest.rb
@@ -58,14 +58,21 @@ class ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest
   def request(url, method: :get, data: nil, verify_ssl: false)
     $nuage_log.debug("Accessing Nuage VSD url #{method} #{url} with data '#{data}'")
     login unless @api_key
-    RestClient::Request.execute(
+
+    options = {
       :url        => url,
       :method     => method,
       :headers    => @headers,
-      :data       => data,
       :user       => @user,
       :password   => @api_key,
       :verify_ssl => verify_ssl
-    ) { |response| response } # silence errors like 404
+    }
+
+    proxy = VMDB::Util.http_proxy_uri(:nuage) || VMDB::Util.http_proxy_uri(:default)
+
+    options[:payload] = data if data
+    options[:proxy] = proxy if proxy
+
+    RestClient::Request.execute(options) { |response| response } # silence errors like 404
   end
 end


### PR DESCRIPTION
Within the `ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest#request`, which is a wrapper for `RestClient::Request#execute`, any requests with a payload will currently fail.

The problem is that the current code is setting the `:data` option, when in fact rest-client uses a `:payload` option:

https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L54
https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L163

Based on my (admittedly vague) recollection from my days writing azure-armrest, even a nil `:payload` will cause problems for requests that don't support them, so that key is only added to the hash of options if the payload is non-nil.

While I was here I also added the `:proxy` option.