### PR TITLE
Use before_install to setup bundle_with qpid_proton

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -23,5 +23,8 @@ make all
 # Install system libraries
 sudo make install
 
+# Enable the qpid_proton bundler group
+[ -z "$BUNDLE_WITH" ] && bundle config with qpid_proton
+
 popd
 set +v


### PR DESCRIPTION
Instead of passing BUNDLE_WITH=qpid_proton as an env var which isn't able to be generically passed by cross_repo-tests we can use `bundle config with` to set it.

This allows cross_repo to just call `tools/ci/before_install.sh` as normal and enable the bundler group without any repo specifics or env var passthroughs.