### PR TITLE
Cleanup spec warnings, fix strict partial failures

### DIFF
--- a/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
+++ b/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
@@ -1,6 +1,5 @@
 describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
-  let(:rest) { class_double("#{described_class}::Rest" ).as_stubbed_const }
-  let(:rest_call) { double(rest, :reset_headers => nil) }
+  let(:rest_call) { instance_double(ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest, :reset_headers => nil) }
 
   let(:client) do
     described_class.new('server', 'username', 'password').tap do |c|
@@ -9,7 +8,6 @@ describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
   end
 
   before do
-    expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest).to receive(:new).with('server', 'username', 'password').and_call_original
     expect_any_instance_of(ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest).to receive(:login)
   end
 

--- a/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
+++ b/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
   let(:rest_call) { double(rest, :reset_headers => nil) }
 
   let(:client) do
-    described_class.new.tap do |c|
+    described_class.new('server', 'username', 'password').tap do |c|
       c.instance_variable_set(:@rest_call, rest_call)
     end
   end

--- a/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
+++ b/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
@@ -1,13 +1,15 @@
 describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
-  before(:each) do
-    allow_any_instance_of(described_class).to receive(:initialize)
+  let(:rest) { class_double("#{described_class}::Rest" ).as_stubbed_const }
+  let(:rest_call) { double(rest, :reset_headers => nil) }
+
+  let(:client) do
+    described_class.new.tap do |c|
+      c.instance_variable_set(:@rest_call, rest_call)
+    end
   end
 
-  let(:rest_call) { double('Rest', :reset_headers => nil) }
-  let(:client) do
-    c = described_class.new
-    c.instance_variable_set(:@rest_call, rest_call)
-    c
+  before do
+    allow_any_instance_of(described_class).to receive(:initialize)
   end
 
   describe "get_list edge cases" do

--- a/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
+++ b/spec/models/manageiq/providers/nuage/vsd_client/vsd_client_spec.rb
@@ -9,7 +9,8 @@ describe ManageIQ::Providers::Nuage::NetworkManager::VsdClient do
   end
 
   before do
-    allow_any_instance_of(described_class).to receive(:initialize)
+    expect(ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest).to receive(:new).with('server', 'username', 'password').and_call_original
+    expect_any_instance_of(ManageIQ::Providers::Nuage::NetworkManager::VsdClient::Rest).to receive(:login)
   end
 
   describe "get_list edge cases" do


### PR DESCRIPTION
The current `VsdClient` specs have a couple issues. First is that the specs fail with strict partials enabled. The issue is that the constructor requires 3 arguments, so I've added some placeholder values.

Second, the way the specs are currently written stub out the `:initialize` method. This seems to make rspec upset, and it spews lots of warnings. See https://github.com/ManageIQ/manageiq-providers-nuage/issues/207 for more details.

Note that I had to fully qualify the `Rest` class, or rspec got confused. I'm not sure if there's a trick to seeing nested classes with rspec, but fully qualifying it is clearer anyway IMO.

Fixes https://github.com/ManageIQ/manageiq-providers-nuage/issues/207