### PR TITLE
Adjusted DDF schema for provider creation with updated validation

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -18,6 +18,11 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
   include Vmdb::Logging
   include ManageIQ::Providers::Nuage::ManagerMixin
 
+  # FIXME: remove this after the provider doesn't belong to a parent_manager
+  def self.supported_for_create?
+    true
+  end
+
   def self.ems_type
     @ems_type ||= "nuage_network".freeze
   end


### PR DESCRIPTION
In order to bypass [`belongs_to`])(https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/network_manager.rb#L37-L40) that's defined globally for all network providers, I had to implement `ManageIQ::Providers::Nuage::NetworkManager.supported_for_create?` to return `true`. It can be removed after the manager link is not set globally for all managers, but only for those which really need it.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

cc @h-kataria 