### PR TITLE
Fix the network manager ems counts

### DIFF
--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/refresher_spec.rb
@@ -101,7 +101,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ExtManagementSystem.count).to eq(3) # nuage + vmware infra
+    expect(ExtManagementSystem.count).to eq(2) # nuage + vmware infra
     expect(CloudTenant.count).to eq(2)
     expect(CloudNetwork.count).to eq(1)
     expect(SecurityGroup.count).to eq(2)

--- a/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/vcr_specs/targeted_refresh_spec.rb
@@ -421,7 +421,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_cloud_subnet_counts
-    expect(ExtManagementSystem.count).to eq(2)
+    expect(ExtManagementSystem.count).to eq(1)
     expect(CloudTenant.count).to eq(0)
     expect(SecurityGroup.count).to eq(0)
     expect(CloudSubnet.count).to eq(1)
@@ -460,7 +460,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_cloud_tenant_counts
-    expect(ExtManagementSystem.count).to eq(2)
+    expect(ExtManagementSystem.count).to eq(1)
     expect(CloudTenant.count).to eq(1)
     expect(SecurityGroup.count).to eq(0)
     expect(CloudSubnet.count).to eq(0)
@@ -481,7 +481,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::Refresher do
   end
 
   def assert_security_group_counts
-    expect(ExtManagementSystem.count).to eq(2)
+    expect(ExtManagementSystem.count).to eq(1)
     expect(CloudTenant.count).to eq(0)
     expect(SecurityGroup.count).to eq(1)
     expect(CloudSubnet.count).to eq(0)


### PR DESCRIPTION
The core ems_network factory auto-creates a parent_manager which is invalid for standalone network_managers.

Depends on: https://github.com/ManageIQ/manageiq/pull/20229
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136