### PR TITLE
Set the monitor_running event to unblock the main thread

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/runner.rb
@@ -15,8 +15,8 @@ class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner < ManageI
 
   # Start monitoring for events. This method blocks forever until stop_event_monitor is called.
   def monitor_events
+    event_monitor_running
     event_monitor_handle.start do |event|
-      event_monitor_running
       @queue.enq(event)
     end
   ensure

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
@@ -13,6 +13,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner do
   end
 
   it '.monitor_events' do
+    allow(subject).to receive(:event_monitor_running)
     allow(subject).to receive(:event_monitor_handle).and_return(handle)
     expect { subject.monitor_events }.not_to raise_error
   end


### PR DESCRIPTION
Without setting the monitor_running concurrent event the main
event_catcher worker thread doesn't ever leave the do_before_work_loop
which means it can't be shutdown cleanly until the first event is
raised.