### PR TITLE
Fix toolbar specs after ui7247

### DIFF
--- a/spec/helpers/manageiq/providers/nuage/toolbar_overrides/network_router_center_spec.rb
+++ b/spec/helpers/manageiq/providers/nuage/toolbar_overrides/network_router_center_spec.rb
@@ -1,5 +1,5 @@
 describe ManageIQ::Providers::Nuage::ToolbarOverrides::NetworkRouterCenter do
-  let(:button_group)  { described_class.definition['nuage_network_router'] }
+  let(:button_group)  { described_class.definition["#{described_class.name}.nuage_network_router"] }
   let(:group_items)   { button_group.buttons }
   let(:dropdown_edit) { group_items.first }
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-classic/pull/7247 changed toolbar group ids to also include the class name,
updating the test to do the same.

Should fix https://travis-ci.com/github/ManageIQ/manageiq-providers-nuage/jobs/369417141#L2397-L2413
