### PR TITLE
Fixed JS syntax error in the create cloud subnet form

### DIFF
--- a/app/javascript/components/create-nuage-cloud-subnet-form.jsx
+++ b/app/javascript/components/create-nuage-cloud-subnet-form.jsx
@@ -17,9 +17,11 @@ const CreateNuageCloudSubnetForm = ({ dispatch }) => {
 
     dispatch({
       type: 'FormButtons.callbacks',
-      payload: { addClicked: () => formOptions.submit() },
+      payload: {
+        addClicked: () => formOptions.submit()
+      },
     });
-  });
+  };
 
   const submitValues = (values) => {
     API.get(`/api/network_routers/${ManageIQ.record.recordId}?attributes=ems_ref,name,ems_id`).then(({ ems_ref: router_ref, ems_id }) =>


### PR DESCRIPTION
Missed an extra `)` :see_no_evil: 