### PR TITLE
convert regexp event detection to strings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,16 +6,16 @@
       :event_groups:
         :addition:
           :critical:
-          - !ruby/regexp /^nuage_.+_create$/
+          - /^nuage_.+_create$/
         :deletion:
           :critical:
-          - !ruby/regexp /^nuage_.+_delete$/
+          - /^nuage_.+_delete$/
         :update:
           :critical:
-          - !ruby/regexp /^nuage_.+_update$/
+          - /^nuage_.+_update$/
         :status: # alarms
           :critical:
-          - !ruby/regexp /^nuage_alarm_.+$/
+          - /^nuage_alarm_.+$/
 :http_proxy:
   :nuage:
     :host:


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/20907

In order to better support json configuration settings, the regular
expressions in settings.yml are being converted to strings.
The event system is now responsible to handle the appropriately