### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/nuage/manager_mixin.rb
+++ b/app/models/manageiq/providers/nuage/manager_mixin.rb
@@ -52,13 +52,14 @@ module ManageIQ::Providers::Nuage::ManagerMixin
                       :validationDependencies => %w[type api_version],
                       :fields                 => [
                         {
-                          :component  => "select",
-                          :id         => "endpoints.default.security_protocol",
-                          :name       => "endpoints.default.security_protocol",
-                          :label      => _("Security Protocol"),
-                          :isRequired => true,
-                          :validate   => [{:type => "required"}],
-                          :options    => [
+                          :component    => "select",
+                          :id           => "endpoints.default.security_protocol",
+                          :name         => "endpoints.default.security_protocol",
+                          :label        => _("Security Protocol"),
+                          :isRequired   => true,
+                          :initialValue => 'ssl-with-validation',
+                          :validate     => [{:type => "required"}],
+                          :options      => [
                             {
                               :label => _("SSL without validation"),
                               :value => "ssl-no-validation"


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare