### PR TITLE
Modified Network Field of Cloud Subnet Form

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet < ::CloudSubnet
           :isRequired   => true,
           :validate     => [{:type => 'required'}],
           :includeEmpty => true,
-          :options      => ems.networks.map do |cvt|
+          :options      => ems.cloud_networks.map do |cvt|
             {
               :label => cvt.name,
               :value => cvt.id,


### PR DESCRIPTION
Changes `ems.network` to `ems.cloud_network` to ensure the Network field correctly displays available networks 