### PR TITLE
Fix deprecated `Module#parent` in CloudTenant

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb
@@ -6,10 +6,10 @@ class ManageIQ::Providers::Nuage::NetworkManager::CloudTenant < ::CloudTenant
   has_many   :floating_ips,    :dependent => :destroy
 
   def l3_cloud_subnets
-    cloud_subnets.where(:type => self.class.parent.l3_cloud_subnet_type)
+    cloud_subnets.where(:type => self.class.module_parent.l3_cloud_subnet_type)
   end
 
   def l2_cloud_subnets
-    cloud_subnets.where(:type => self.class.parent.l2_cloud_subnet_type)
+    cloud_subnets.where(:type => self.class.module_parent.l2_cloud_subnet_type)
   end
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from l3_cloud_subnets at /home/travis/build/ManageIQ/manageiq-providers-nuage/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb:9)

DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from l2_cloud_subnets at /home/travis/build/ManageIQ/manageiq-providers-nuage/app/models/manageiq/providers/nuage/network_manager/cloud_tenant.rb:13)
```