### PR TITLE
Refactor create cloud subnet queue

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -132,24 +132,6 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
     ansible_root.join(name)
   end
 
-  # TODO(miha-plesko): move to core
-  def create_cloud_subnet_queue(userid, options = {})
-    task_opts = {
-      :action => "creating Cloud Subnet for user #{userid}",
-      :userid => userid
-    }
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'create_cloud_subnet',
-      :instance_id => id,
-      :priority    => MiqQueue::NORMAL_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => [options]
-    }
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
   def create_cloud_subnet(options)
     self.class::CloudSubnet.raw_create_cloud_subnet(self, options)
   end


### PR DESCRIPTION
- `create_cloud_subnet_queue` method lives in the provider code but it is unnecessary and can be moved to core

Depends on:

* [x] [Refactor create cloud subnet queue from providers](https://github.com/ManageIQ/manageiq/pull/21313)