### PR TITLE
Use standard persister builder methods from core

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister/definitions/network_collections.rb
@@ -2,17 +2,16 @@ module ManageIQ::Providers::Nuage::Inventory::Persister::Definitions::NetworkCol
   extend ActiveSupport::Concern
 
   def initialize_network_inventory_collections
-    %i(cloud_tenants
-       cloud_subnets
-       security_groups
-       cloud_networks
-       floating_ips
-       network_ports
-       network_routers).each do |name|
-
-      add_collection(network, name) do |builder|
-        builder.add_properties(:parent => manager) # including targeted
-      end
+    %i[
+      cloud_tenants
+      cloud_subnets
+      security_groups
+      cloud_networks
+      floating_ips
+      network_ports
+      network_routers
+    ].each do |name|
+      add_network_collection(name)
     end
 
     add_cloud_subnet_network_ports
@@ -20,9 +19,9 @@ module ManageIQ::Providers::Nuage::Inventory::Persister::Definitions::NetworkCol
   end
 
   def add_cloud_subnet_network_ports(extra_properties = {})
-    add_collection(network, :cloud_subnet_network_ports, extra_properties) do |builder|
+    add_network_collection(:cloud_subnet_network_ports, extra_properties) do |builder|
       builder.add_properties(:manager_ref_allowed_nil => %i(cloud_subnet))
-      builder.add_properties(:parent => manager, :parent_inventory_collections => %i(network_ports))
+      builder.add_properties(:parent_inventory_collections => %i(network_ports))
     end
   end
 


### PR DESCRIPTION
The handling of the "parent" manager has been added as a feature of the `add_TYPE_collection` methods in core.