### PR TITLE
[WIP] Upgrade Node v14 to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0",
+    "node": ">= 16.0.0",
+    "npm": ">= 8.0.0",
     "yarn": ">= 0.20.1"
   },
   "jest": {


### PR DESCRIPTION
Upgrade `Node 14` to `Node 16`

**Dependency**
Upgrading `npm` version from **6.0.0 to 8.0.0**
You need to install npm version **7.0.0** or above in order to run **node v16.**

Previous - https://github.com/ManageIQ/manageiq-providers-nuage/pull/263

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8146