### PR TITLE
Fix xlab-si galaxy roles pointing to invalid repository URL

### DIFF
--- a/content/ansible_runner/create-subnet.yml
+++ b/content/ansible_runner/create-subnet.yml
@@ -9,7 +9,7 @@
   gather_facts: False
   tasks:
   - include_role:
-      name: xlab_si.nuage_create_entity
+      name: xlab-si.nuage_create_entity
     vars:
       entity_type: Zone
       parent_type: Domain
@@ -17,7 +17,7 @@
       attributes:
         name: 'CloudForms Subnets'
   - include_role:
-      name: xlab_si.nuage_create_entity
+      name: xlab-si.nuage_create_entity
     vars:
       entity_type: Subnet
       parent_type: Zone

--- a/content/ansible_runner/remove-floating-ip.yml
+++ b/content/ansible_runner/remove-floating-ip.yml
@@ -9,4 +9,4 @@
   vars:
     entity_type: FloatingIp
   roles:
-  - xlab_si.nuage_remove_entity
+  - xlab-si.nuage_remove_entity

--- a/content/ansible_runner/remove-policy-group.yml
+++ b/content/ansible_runner/remove-policy-group.yml
@@ -9,4 +9,4 @@
   vars:
     entity_type: PolicyGroup
   roles:
-  - xlab_si.nuage_remove_entity
+  - xlab-si.nuage_remove_entity

--- a/content/ansible_runner/remove-subnet.yml
+++ b/content/ansible_runner/remove-subnet.yml
@@ -11,4 +11,4 @@
     kind: L3
     entity_type: "{{ 'L2Domain' if kind == 'L2' else 'Subnet' }}"
   roles:
-  - xlab_si.nuage_remove_entity
+  - xlab-si.nuage_remove_entity

--- a/content/ansible_runner/roles/requirements.yml
+++ b/content/ansible_runner/roles/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: xlab_si.nuage_remove_entity
+- src: xlab-si.nuage_remove_entity
   version: v0.1.0
-- src: xlab_si.nuage_create_entity
+- src: xlab-si.nuage_create_entity
   version: v0.1.0


### PR DESCRIPTION
The GitHub repos have moved from xlab_si to xlab-si which is causing the
old galaxy roles links to fail with a 404 error.