### PR TITLE
Require the gem defining the constant we're subclassing

### DIFF
--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb
@@ -1,9 +1,8 @@
+require 'qpid_proton'
 class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler < Qpid::Proton::MessagingHandler
   attr_reader :errors
 
   def initialize(options = {})
-    require 'qpid_proton'
-
     super()
     @options = options
 

--- a/lib/manageiq/providers/nuage/engine.rb
+++ b/lib/manageiq/providers/nuage/engine.rb
@@ -11,6 +11,12 @@ module ManageIQ
           app.config.paths["config/secrets"] << root.join("config", "secrets.yml").to_s
         end
 
+        initializer 'manageiq-providers-nuage.configure_autoloader' do
+          # The following file should not be eager loaded as it depends on being installed, which isn't possible on macs and isn't done by default
+          # in ci for other plugins, core, etc.
+          Rails.autoloaders.main.ignore(root.join("app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb")) unless Gem.loaded_specs.key?('qpid_proton')
+        end
+
         def self.vmdb_plugin?
           true
         end

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler_spec.rb
@@ -1,4 +1,6 @@
-describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler do
+# Note, we're using string class name to avoid autoloading the class since it requires
+# qpid_proton installed.
+describe "ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler", :qpid_proton => true do
   before do
     subject.instance_variable_set(:@conn, conn)
   end
@@ -7,7 +9,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHand
   let(:container) { double('container', :stopped => false, :stop => nil) }
   let(:conn)      { double('connection', :open_receiver => nil, :container => container) }
 
-  subject { described_class.new(options) }
+  subject { ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::MessagingHandler.new(options) }
 
   it 'default connection timeout' do
     expect(subject.instance_variable_get(:@timeout)).to eq(5.seconds)

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/runner_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Runner do
   let(:ems)    { FactoryBot.create(:ems_nuage_network_with_authentication) }
   let(:handle) { double('handle', :start => nil) }
 
-  it '.event_monitor_handle' do
+  it '.event_monitor_handle', :qpid_proton => true do
     expect(subject.event_monitor_handle).not_to be_nil
   end
 

--- a/spec/models/manageiq/providers/nuage/network_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager/event_catcher/stream_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream do
+describe ManageIQ::Providers::Nuage::NetworkManager::EventCatcher::Stream, :qpid_proton => true do
   before do
     allow(subject).to receive(:connection).and_return(conn)
   end

--- a/spec/models/manageiq/providers/nuage/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/nuage/network_manager_spec.rb
@@ -72,9 +72,10 @@ describe ManageIQ::Providers::Nuage::NetworkManager do
       end.to raise_error(MiqException::MiqInvalidCredentialsError)
     end
 
-    context 'AMQP connection' do
+    context 'AMQP connection', :qpid_proton => true do
       before do
         @conn = double('connection', :handler => handler)
+        require 'qpid_proton'
         allow(Qpid::Proton::Container).to receive(:new).and_return(@conn)
 
         creds = {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,10 @@ Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 require "manageiq/providers/nuage"
-require "qpid_proton"
+
+RSpec.configure do |config|
+  config.filter_run_excluding(:qpid_proton) unless ENV['CI'] || Gem.loaded_specs.key?('qpid_proton')
+end
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
* We're not setup to autoload the library so we need to manually require the gem before using it.
* Some environments don't have qpid_proton installed so explicitly tell zeitwerk to not autoload or eager load the messaging handler
* Mark specs requiring qpid_proton and exclude them if not available

Related change that should be merged together: https://github.com/ManageIQ/manageiq/pull/22763