### PR TITLE
Revert "Merge pull request #298 from agrare/replace_xlab_si_with_xlab-si"

### DIFF
--- a/content/ansible_runner/create-subnet.yml
+++ b/content/ansible_runner/create-subnet.yml
@@ -9,7 +9,7 @@
   gather_facts: False
   tasks:
   - include_role:
-      name: xlab-si.nuage_create_entity
+      name: xlab_si.nuage_create_entity
     vars:
       entity_type: Zone
       parent_type: Domain
@@ -17,7 +17,7 @@
       attributes:
         name: 'CloudForms Subnets'
   - include_role:
-      name: xlab-si.nuage_create_entity
+      name: xlab_si.nuage_create_entity
     vars:
       entity_type: Subnet
       parent_type: Zone

--- a/content/ansible_runner/remove-floating-ip.yml
+++ b/content/ansible_runner/remove-floating-ip.yml
@@ -9,4 +9,4 @@
   vars:
     entity_type: FloatingIp
   roles:
-  - xlab-si.nuage_remove_entity
+  - xlab_si.nuage_remove_entity

--- a/content/ansible_runner/remove-policy-group.yml
+++ b/content/ansible_runner/remove-policy-group.yml
@@ -9,4 +9,4 @@
   vars:
     entity_type: PolicyGroup
   roles:
-  - xlab-si.nuage_remove_entity
+  - xlab_si.nuage_remove_entity

--- a/content/ansible_runner/remove-subnet.yml
+++ b/content/ansible_runner/remove-subnet.yml
@@ -11,4 +11,4 @@
     kind: L3
     entity_type: "{{ 'L2Domain' if kind == 'L2' else 'Subnet' }}"
   roles:
-  - xlab-si.nuage_remove_entity
+  - xlab_si.nuage_remove_entity

--- a/content/ansible_runner/roles/requirements.yml
+++ b/content/ansible_runner/roles/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: xlab-si.nuage_remove_entity
+- src: xlab_si.nuage_remove_entity
   version: v0.1.0
-- src: xlab-si.nuage_create_entity
+- src: xlab_si.nuage_create_entity
   version: v0.1.0


### PR DESCRIPTION
Xlab-si has moved back to using the xlab_si namespace on ansible galaxy.

Revert of https://github.com/ManageIQ/manageiq-providers-nuage/pull/298

This reverts commit 541494cded64b1ef281c71767d7d5f88cf4bb08d, reversing changes made to a4f9d86e0e38d3d3d21d0617fbd21cf81fe1344b.