### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/nuage/inventory.rb
+++ b/app/models/manageiq/providers/nuage/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Nuage::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/nuage/inventory/collector.rb
+++ b/app/models/manageiq/providers/nuage/inventory/collector.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Nuage::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   def initialize(_manager, _target)
     super
 

--- a/app/models/manageiq/providers/nuage/inventory/parser.rb
+++ b/app/models/manageiq/providers/nuage/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Nuage::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :NetworkManager
 end

--- a/app/models/manageiq/providers/nuage/inventory/persister.rb
+++ b/app/models/manageiq/providers/nuage/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Nuage::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :NetworkManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -1,18 +1,5 @@
 class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkManager
   include SupportsFeatureMixin
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :VsdClient
-  require_nested :CloudTenant
-  require_nested :NetworkRouter
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :SecurityGroup
-  require_nested :FloatingIp
-  require_nested :NetworkPort
-
   supports :cloud_subnet_create
   supports :create
   supports :update

--- a/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Nuage::NetworkManager::EventCatcher < ::MiqEventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_nuage_network
   end

--- a/app/models/manageiq/providers/nuage/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_nuage_network
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854